### PR TITLE
Support x-api-key header authentication and update Claude Code setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,30 @@ Proxy 启动后，将客户端指向 raven：
 
 <details><summary><strong>Claude Code</strong></summary>
 
+在 `~/.zshrc`（或你使用的 shell 配置文件）中添加：
+
 ```bash
-# Anthropic 格式
-claude config set --global apiUrl http://localhost:7033/v1
+export ANTHROPIC_BASE_URL=http://localhost:7033
+export ANTHROPIC_API_KEY=<你的 RAVEN_API_KEY>
 ```
+
+然后 `source ~/.zshrc` 或重开终端。
+
+**首次启动交互模式的额外步骤：**
+
+Claude Code 交互模式会对 `ANTHROPIC_API_KEY` 进行审批确认。首次运行 `claude` 时会弹出 "Do you want to use this API key?" 对话框，**选择 Yes**。
+
+如果之前误选了 No，key 会被加入拒绝列表，需要手动修复 `~/.claude.json`：
+
+```jsonc
+// 将 key 的后 20 位字符从 rejected 移到 approved
+"customApiKeyResponses": {
+  "approved": ["<key 的后 20 位>"],
+  "rejected": []
+}
+```
+
+> **注意**：`claude --print`（非交互模式）不需要这个审批步骤，直接读取环境变量即可。
 
 </details>
 

--- a/packages/proxy/src/middleware.ts
+++ b/packages/proxy/src/middleware.ts
@@ -72,12 +72,21 @@ function validateBearerToken(
   envApiKey?: string,
   internalKey?: string,
 ): { valid: true; keyName: string } | { valid: false; response: Response } {
+  // Accept token from Authorization: Bearer <token> or x-api-key: <token>
+  // (Claude Code sends x-api-key when ANTHROPIC_BASE_URL != api.anthropic.com)
   const authHeader = c.req.header("Authorization");
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return { valid: false, response: unauthorized(c, "Missing or malformed Authorization header") };
+  const xApiKey = c.req.header("x-api-key");
+
+  let token: string | undefined;
+  if (authHeader?.startsWith("Bearer ")) {
+    token = authHeader.slice(7);
+  } else if (xApiKey) {
+    token = xApiKey;
   }
 
-  const token = authHeader.slice(7); // strip "Bearer "
+  if (!token) {
+    return { valid: false, response: unauthorized(c, "Missing or malformed Authorization header") };
+  }
 
   // rk- prefix → DB lookup only, never fallback to env
   if (token.startsWith("rk-")) {


### PR DESCRIPTION
## Summary

This PR adds support for x-api-key header authentication and updates the Claude Code setup documentation to use environment variables instead of the deprecated `claude config set` command.

## Changes Made

### 1. API Authentication Enhancement (`packages/proxy/src/middleware.ts`)
- Added support for `x-api-key` header authentication alongside existing `Authorization: Bearer`
- Claude Code sends credentials via `x-api-key` header when `ANTHROPIC_BASE_URL` points to non-Anthropic hosts
- `Authorization: Bearer` takes precedence when both headers are present
- Maintains backward compatibility with existing clients

### 2. Documentation Update (`README.md`)  
- Replaced obsolete `claude config set --global apiUrl` with `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` environment variables
- Added detailed setup instructions for Claude Code interactive mode
- Documented the API key approval process and troubleshooting steps
- Included notes about `~/.claude.json` configuration for rejected keys

## Technical Details

The middleware now accepts authentication tokens from either:
- `Authorization: Bearer <token>` (existing behavior)
- `x-api-key: <token>` (new support for Claude Code)

This change enables seamless integration with Claude Code when using custom API endpoints.

## Testing

- Verified both authentication methods work correctly
- Tested Claude Code integration with the updated environment variable setup
- Confirmed backward compatibility with existing Authorization header usage

## Commits

- `d6ebb72` fix: accept x-api-key header for API authentication
- `c5c03e0` docs: update Claude Code setup instructions for env var auth