### PR TITLE
feat: intercept Claude Code web search via Tavily

### DIFF
--- a/packages/proxy/.env.example
+++ b/packages/proxy/.env.example
@@ -26,3 +26,11 @@ RAVEN_LOG_LEVEL=info
 # Leave empty to default to http://localhost:$RAVEN_PORT.
 # Set this when running behind a reverse proxy or custom hostname.
 RAVEN_BASE_URL=
+
+# Tavily API key for web search interception.
+# When set, Claude Code's WebSearch requests (web_search_20250305 server tool)
+# are intercepted and resolved via Tavily instead of failing silently against
+# the Copilot upstream which does not support Anthropic server tools.
+# Get a free key at https://tavily.com (1,000 searches/month).
+# Leave empty to disable — web search requests will pass through as-is.
+TAVILY_API_KEY=

--- a/packages/proxy/src/routes/messages/handler.ts
+++ b/packages/proxy/src/routes/messages/handler.ts
@@ -52,6 +52,145 @@ export async function handleCompletion(c: Context) {
     },
   })
 
+  // ---------------------------------------------------------------------------
+  // Web Search interception — Tavily
+  //
+  // Claude Code sends a dedicated sub-request for web search with a server tool
+  // ({type: "web_search_20250305"}) in the tools array.  The Copilot upstream
+  // does not support Anthropic server tools, so the request would fail silently.
+  //
+  // When TAVILY_API_KEY is configured we short-circuit the request here: call
+  // Tavily for search results and return an Anthropic-native response containing
+  // server_tool_use + web_search_tool_result blocks that Claude Code expects.
+  // ---------------------------------------------------------------------------
+  const webSearchServerTool = (anthropicPayload as Record<string, unknown>).tools
+    ? (anthropicPayload.tools as Array<Record<string, unknown>>)?.find(
+        (t) => typeof t.type === "string" && (t.type as string).startsWith("web_search_"),
+      )
+    : undefined
+
+  if (webSearchServerTool && process.env.TAVILY_API_KEY) {
+    // Extract the search query from the first user message.
+    // Claude Code sends: "Perform a web search for the query: <query>"
+    const firstMsg = anthropicPayload.messages[0]
+    const rawContent =
+      typeof firstMsg?.content === "string"
+        ? firstMsg.content
+        : Array.isArray(firstMsg?.content)
+          ? firstMsg.content
+              .filter((b) => "text" in b && b.type === "text")
+              .map((b) => ("text" in b ? (b as { text: string }).text : ""))
+              .join(" ")
+          : ""
+    const query =
+      rawContent.replace(/^Perform a web search for the query:\s*/i, "").trim() || rawContent
+
+    // Call Tavily
+    let searchResults: Array<{ url: string; title: string; content: string }> = []
+    try {
+      const tavilyResp = await fetch("https://api.tavily.com/search", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.TAVILY_API_KEY}`,
+        },
+        body: JSON.stringify({ query, max_results: 5 }),
+      })
+      const tavilyData = (await tavilyResp.json()) as {
+        results?: Array<{ url: string; title: string; content: string }>
+      }
+      searchResults = tavilyData.results ?? []
+    } catch {
+      // Tavily unavailable — we'll return empty results below
+    }
+
+    // Build Anthropic-native response blocks
+    const srvId = `srvtoolu_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+    const webResults = searchResults.map((r) => ({
+      type: "web_search_result" as const,
+      url: r.url,
+      title: r.title,
+      encrypted_content: "" as const,
+      page_age: null as null,
+    }))
+    const summaryText = searchResults.length
+      ? searchResults.map((r) => `${r.title}\n${r.url}\n${r.content}`).join("\n\n---\n\n")
+      : "No results found."
+
+    const contentBlocks = [
+      { type: "server_tool_use" as const, id: srvId, name: "web_search", input: { query } },
+      { type: "web_search_tool_result" as const, tool_use_id: srvId, content: webResults },
+      { type: "text" as const, text: summaryText },
+    ]
+    const responseBody = {
+      id: `msg_${requestId}`,
+      type: "message" as const,
+      role: "assistant" as const,
+      model,
+      content: contentBlocks,
+      stop_reason: "end_turn" as const,
+      stop_sequence: null as null,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }
+
+    const latencyMs = Math.round(performance.now() - startTime)
+    logEmitter.emitLog({
+      ts: Date.now(), level: "info", type: "request_end", requestId,
+      msg: `200 web_search (tavily) ${latencyMs}ms`,
+      data: {
+        path: "/v1/messages", format: "anthropic", model,
+        latencyMs, stream, status: "success", statusCode: 200,
+        accountName, sessionId, clientName, clientVersion,
+      },
+    })
+
+    if (!stream) {
+      return c.json(responseBody)
+    }
+
+    // Streaming: emit SSE events matching the Anthropic streaming protocol.
+    // Claude Code parses server_tool_use via content_block_start, reads the
+    // query from input_json_delta, and reads results from content_block_start
+    // of web_search_tool_result.
+    return streamSSE(c, async (sseStream) => {
+      const emit = (event: string, data: unknown) =>
+        sseStream.writeSSE({ event, data: JSON.stringify(data) })
+
+      await emit("message_start", {
+        type: "message_start",
+        message: { ...responseBody, content: [], stop_reason: null },
+      })
+
+      for (let i = 0; i < contentBlocks.length; i++) {
+        await emit("content_block_start", {
+          type: "content_block_start",
+          index: i,
+          content_block: contentBlocks[i],
+        })
+        // Claude Code extracts the search query from input_json_delta events
+        if (contentBlocks[i].type === "server_tool_use") {
+          await emit("content_block_delta", {
+            type: "content_block_delta",
+            index: i,
+            delta: {
+              type: "input_json_delta",
+              partial_json: JSON.stringify(contentBlocks[i].input),
+            },
+          })
+        }
+        await emit("content_block_stop", { type: "content_block_stop", index: i })
+      }
+
+      await emit("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 0 },
+      })
+      await emit("message_stop", { type: "message_stop" })
+    })
+  }
+  // --- End Web Search interception ---
+
   const openAIPayload = translateToOpenAI(anthropicPayload)
 
   try {

--- a/packages/proxy/test/routes/messages-handler.test.ts
+++ b/packages/proxy/test/routes/messages-handler.test.ts
@@ -432,3 +432,155 @@ describe("messages handler (errors)", () => {
     expect(endEvent!.data?.error).toContain("stream error")
   })
 })
+
+// ===========================================================================
+// handleCompletion — web search interception (Tavily)
+// ===========================================================================
+
+describe("messages handler (web search interception)", () => {
+  const savedTavilyKey = process.env.TAVILY_API_KEY
+
+  afterEach(() => {
+    if (savedTavilyKey !== undefined) process.env.TAVILY_API_KEY = savedTavilyKey
+    else delete process.env.TAVILY_API_KEY
+  })
+
+  test("short-circuits web search request when TAVILY_API_KEY is set", async () => {
+    process.env.TAVILY_API_KEY = "tvly-test-key"
+
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchJson({
+        results: [
+          { url: "https://example.com", title: "Example", content: "Test content" },
+        ],
+      }),
+    )
+
+    const app = makeApp()
+    const res = await app.request(
+      req({
+        model: "claude-sonnet-4",
+        max_tokens: 4096,
+        messages: [{ role: "user", content: "Perform a web search for the query: latest bun version" }],
+        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as Record<string, unknown>
+    expect(json.type).toBe("message")
+
+    // Should contain server_tool_use + web_search_tool_result + text
+    const content = json.content as Array<{ type: string }>
+    expect(content).toHaveLength(3)
+    expect(content[0].type).toBe("server_tool_use")
+    expect(content[1].type).toBe("web_search_tool_result")
+    expect(content[2].type).toBe("text")
+
+    // Tavily was called (not Copilot)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const callUrl = fetchSpy.mock.calls[0][0] as string
+    expect(callUrl).toBe("https://api.tavily.com/search")
+  })
+
+  test("passes through to Copilot when TAVILY_API_KEY is not set", async () => {
+    delete process.env.TAVILY_API_KEY
+
+    fetchSpy.mockResolvedValueOnce(mockFetchJson(makeOpenAIResponse()))
+
+    const app = makeApp()
+    const res = await app.request(
+      req({
+        model: "claude-sonnet-4",
+        max_tokens: 4096,
+        messages: [{ role: "user", content: "Perform a web search for the query: test" }],
+        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    // Should go through normal Copilot path (Anthropic response format)
+    const json = (await res.json()) as Record<string, unknown>
+    expect(json.type).toBe("message")
+    expect(json.stop_reason).toBe("end_turn") // from Copilot translation
+  })
+
+  test("returns empty results when Tavily is unavailable", async () => {
+    process.env.TAVILY_API_KEY = "tvly-test-key"
+
+    fetchSpy.mockRejectedValueOnce(new Error("network error"))
+
+    const app = makeApp()
+    const res = await app.request(
+      req({
+        model: "claude-sonnet-4",
+        max_tokens: 4096,
+        messages: [{ role: "user", content: "Perform a web search for the query: test" }],
+        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as Record<string, unknown>
+    const content = json.content as Array<{ type: string; text?: string }>
+    const textBlock = content.find((b) => b.type === "text")
+    expect(textBlock?.text).toBe("No results found.")
+  })
+
+  test("streaming web search returns valid SSE events", async () => {
+    process.env.TAVILY_API_KEY = "tvly-test-key"
+
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchJson({
+        results: [
+          { url: "https://example.com", title: "Example", content: "Result text" },
+        ],
+      }),
+    )
+
+    const app = makeApp()
+    const res = await app.request(
+      req({
+        model: "claude-sonnet-4",
+        max_tokens: 4096,
+        stream: true,
+        messages: [{ role: "user", content: "Perform a web search for the query: test query" }],
+        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+
+    // Should contain the expected SSE event types
+    expect(text).toContain("message_start")
+    expect(text).toContain("content_block_start")
+    expect(text).toContain("content_block_stop")
+    expect(text).toContain("input_json_delta")
+    expect(text).toContain("message_delta")
+    expect(text).toContain("message_stop")
+    expect(text).toContain("server_tool_use")
+    expect(text).toContain("web_search_tool_result")
+  })
+
+  test("does not intercept normal requests without web_search server tool", async () => {
+    process.env.TAVILY_API_KEY = "tvly-test-key"
+
+    fetchSpy.mockResolvedValueOnce(mockFetchJson(makeOpenAIResponse()))
+
+    const app = makeApp()
+    const res = await app.request(
+      req({
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 4096,
+        messages: [{ role: "user", content: "hello" }],
+        tools: [{ name: "get_weather", input_schema: { type: "object" } }],
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    // Should go through Copilot, not Tavily
+    const callUrl = fetchSpy.mock.calls[0][0] as string
+    expect(callUrl).not.toContain("tavily")
+  })
+})


### PR DESCRIPTION
## Summary

- Claude Code's WebSearch sends a dedicated sub-request with `{type: "web_search_20250305"}` server tool in the tools array
- The Copilot upstream **does not support** Anthropic server tools, so these requests currently fail silently
- When `TAVILY_API_KEY` is configured, this PR short-circuits web search requests at the handler level, calling Tavily and returning Anthropic-native `server_tool_use` + `web_search_tool_result` blocks

## How it works

```
Claude Code → POST /v1/messages (web search sub-request)
  tools: [{type: "web_search_20250305", name: "web_search"}]
    ↓
Raven handler: detects server tool → calls Tavily API
    ↓
Returns Anthropic-native response:
  - server_tool_use block (with input_json_delta for query)
  - web_search_tool_result block (title + url per result)
  - text block (summary)
    ↓
Claude Code: parses results via BB_() → returns to main conversation
```

## Implementation details

- **Handler short-circuit**: intercepts before the translation layer, never hits Copilot for search requests
- **Streaming + non-streaming**: full SSE event sequence matching Anthropic's protocol (message_start → content_block_start → input_json_delta → content_block_stop → … → message_stop)
- **Graceful degradation**: if Tavily is unavailable, returns empty results (no crash)
- **Fully backward-compatible**: without `TAVILY_API_KEY`, behavior is completely unchanged
- **Logged**: web search requests appear in raven's analytics pipeline

## Changes

| File | Change |
|------|--------|
| `packages/proxy/src/routes/messages/handler.ts` | Web search interception logic (~140 lines including comments) |
| `packages/proxy/.env.example` | Added `TAVILY_API_KEY` documentation |
| `packages/proxy/test/routes/messages-handler.test.ts` | 5 new test cases |

## Setup

```bash
# Add to packages/proxy/.env.local
TAVILY_API_KEY=tvly-your-key-here
# Free tier: 1,000 searches/month at https://tavily.com
```

## Test plan

- [x] 5 new unit tests passing (interception, passthrough, error handling, streaming, bypass)
- [x] All 495 existing proxy unit tests passing
- [x] ESLint clean
- [x] TypeScript type check clean
- [ ] Manual test with Claude Code connected to raven (requires Tavily key + Copilot subscription)

## Background

This was developed through a [10-round iterative code review](https://github.com/Zey413/raven-review), including reverse-engineering Claude Code's `cli.js` to understand the exact WebSearch mechanism (deferred tool → independent sub-request → `extraToolSchemas` merged into tools array → server_tool_use/web_search_tool_result parsing in `BB_()` function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)