### PR TITLE
fix: resolve model variant (1m, fast) from anthropic-beta header

### DIFF
--- a/packages/proxy/src/routes/messages/count-tokens-handler.ts
+++ b/packages/proxy/src/routes/messages/count-tokens-handler.ts
@@ -16,10 +16,11 @@ export async function handleCountTokens(c: Context) {
 
     const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()
 
-    const openAIPayload = translateToOpenAI(anthropicPayload)
+    const openAIPayload = translateToOpenAI(anthropicPayload, { anthropicBeta: anthropicBeta ?? null })
 
+    const translatedModel = openAIPayload.model
     const selectedModel = state.models?.data.find(
-      (model) => model.id === anthropicPayload.model,
+      (model) => model.id === translatedModel || model.id === anthropicPayload.model,
     )
 
     if (!selectedModel) {

--- a/packages/proxy/src/routes/messages/handler.ts
+++ b/packages/proxy/src/routes/messages/handler.ts
@@ -48,6 +48,7 @@ export async function handleCompletion(c: Context) {
   const stream = !!anthropicPayload.stream
   const accountName = c.get("keyName") ?? "default"
   const userAgent = c.req.header("user-agent") ?? null
+  const anthropicBeta = c.req.header("anthropic-beta") ?? null
   const userId = anthropicPayload.metadata?.user_id ?? null
   const { sessionId, clientName, clientVersion } = deriveClientIdentity(userId, userAgent, accountName, null)
 
@@ -109,7 +110,7 @@ export async function handleCompletion(c: Context) {
       })
     }
 
-    const openAIPayload = translateToOpenAI(anthropicPayload, { targetFormat })
+    const openAIPayload = translateToOpenAI(anthropicPayload, { targetFormat, anthropicBeta })
     return handleOpenAIUpstream(
       c,
       requestId,
@@ -121,7 +122,7 @@ export async function handleCompletion(c: Context) {
     )
   }
 
-  const openAIPayload = translateToOpenAI(anthropicPayload, { targetFormat: "copilot" })
+  const openAIPayload = translateToOpenAI(anthropicPayload, { targetFormat: "copilot", anthropicBeta })
 
   // Debug log if thinking was requested but dropped (Copilot doesn't support it)
   if (anthropicPayload.thinking?.type === "enabled") {

--- a/packages/proxy/src/routes/messages/non-stream-translation.ts
+++ b/packages/proxy/src/routes/messages/non-stream-translation.ts
@@ -177,6 +177,7 @@ export type TranslateTargetFormat = "openai-reasoning" | "openai" | "copilot"
 
 export interface TranslateToOpenAIOptions {
   targetFormat?: TranslateTargetFormat
+  anthropicBeta?: string | null
 }
 
 export function translateToOpenAI(
@@ -184,7 +185,7 @@ export function translateToOpenAI(
   options?: TranslateToOpenAIOptions,
 ): ExtendedChatCompletionsPayload {
   const base = {
-    model: translateModelName(payload.model),
+    model: translateModelName(payload.model, options?.anthropicBeta ?? null),
     messages: translateAnthropicMessagesToOpenAI(
       payload.messages,
       payload.system ?? undefined,
@@ -227,23 +228,35 @@ export function translateToOpenAI(
   } as ExtendedChatCompletionsPayload
 }
 
-function translateModelName(model: string): string {
+function translateModelName(model: string, anthropicBeta: string | null): string {
+  // Parse beta flags from anthropic-beta header
+  const betas = anthropicBeta?.split(",").map((b) => b.trim()) ?? []
+  const wants1m = betas.some((b) => b.startsWith("context-1m-"))
+  const wantsFast = betas.some((b) => b.startsWith("fast-mode-"))
+
   // Map from Anthropic SDK model identifiers (hyphenated, with date suffixes)
   // to Copilot model IDs (dot-separated, no date suffix).
+  // Model variant suffixes (-1m, -fast) are determined by anthropic-beta header.
   //
   // Examples:
-  //   claude-opus-4-6-20250820     → claude-opus-4.6
-  //   claude-opus-4-6-1m-20250820  → claude-opus-4.6-1m
+  //   claude-opus-4-6-20250820     → claude-opus-4.6 (or .6-1m / .6-fast per beta)
+  //   claude-opus-4-6-1m-20250820  → claude-opus-4.6-1m (explicit in model name)
+  //   claude-opus-4-6[1m]          → claude-opus-4.6-1m (bracket notation)
   //   claude-sonnet-4-5-20250514   → claude-sonnet-4.5
   //   claude-sonnet-4-20250514     → claude-sonnet-4
   //   claude-haiku-4-5-20251001    → claude-haiku-4.5
   const match = model.match(
-    /^(claude-(?:opus|sonnet|haiku))-(\d+)-(\d{1,2})(?:-(1m))?(?:-\d{8})?$/
+    /^(claude-(?:opus|sonnet|haiku))-(\d+)-(\d{1,2})(?:(?:-|\[)(1m|fast)\]?)?(?:-\d{8})?$/
   )
   if (match) {
     const [, family, major, minor, suffix] = match
     const base = `${family}-${major}.${minor}`
-    return suffix ? `${base}-${suffix}` : base
+    // Explicit suffix in model name takes priority
+    if (suffix) return `${base}-${suffix}`
+    // Otherwise, check anthropic-beta header for variant
+    if (wants1m) return `${base}-1m`
+    if (wantsFast) return `${base}-fast`
+    return base
   }
 
   // No minor version: claude-{family}-{major}[-date]


### PR DESCRIPTION
## Summary

  - Claude Code sends model variants (1M context, Fast mode) via the `anthropic-beta` header, not in the model name. For example, selecting
  "Opus 4.6 (1M Context)" sends `model: claude-opus-4-6` in the body with `anthropic-beta: context-1m-2025-08-07` in the header.
  - Raven ignored this header and always forwarded the base model (e.g. `claude-opus-4.6`), causing requests to hit the 168k token limit
  instead of the 1M context window.
  - The count-tokens handler also failed to match models because it compared the raw Anthropic model name against the Copilot model catalog,
  resulting in "Model not found" warnings.

  ## Changes

  1. **Read `anthropic-beta` header** in the messages handler and pass it through to `translateToOpenAI`
  2. **`translateModelName` now resolves variant suffixes** from the beta header:
     - `context-1m-*` → append `-1m` (e.g. `claude-opus-4.6-1m`)
     - `fast-mode-*` → append `-fast` (e.g. `claude-opus-4.6-fast`)
     - Explicit suffixes in the model name (`-1m`, `-fast`, `[1m]`) still take priority
  3. **Fix count-tokens model lookup** to match using both translated and original model names

  ## Test plan

  - [x] All 1038 proxy tests pass
  - [x] All 266 dashboard tests pass
  - [x] Typecheck passes
  - [x] Coverage 96.9% (above 90% threshold)
  - [x] Verified via proxy logs: `resolved_model` shows `claude-opus-4.6-1m` when `context-1m-*` beta is present
  - [x] Verified: requests with >168k tokens succeed with fix, fail without (400: `prompt token count exceeds the limit of 168000`)
  - [x] Verified: "Model not found" warning no longer appears in count-tokens handler