### PR TITLE
fix(ui): align bg-card usage to B05 luminance spec

### DIFF
--- a/packages/dashboard/src/app/logs/logs-content.tsx
+++ b/packages/dashboard/src/app/logs/logs-content.tsx
@@ -205,7 +205,7 @@ function SystemEventCard({ event }: { event: LogEvent }) {
       </div>
       <div
         className={cn(
-          "flex-1 rounded-lg border bg-card p-3 font-mono text-xs",
+          "flex-1 rounded-lg bg-secondary p-3 font-mono text-xs",
           event.level === "error" && "border-destructive/30",
           event.level === "warn" && "border-warning/30",
         )}
@@ -359,7 +359,7 @@ function RequestCard({
       </div>
       <div
         className={cn(
-          "flex-1 rounded-lg border bg-card overflow-hidden",
+          "flex-1 rounded-lg bg-secondary overflow-hidden",
           isError ? "border-destructive/30" : "border-border",
         )}
       >
@@ -834,7 +834,7 @@ export function LogsContent() {
             className="flex-1 overflow-y-auto"
           >
             {groups.length === 0 ? (
-              <div className="flex h-32 items-center justify-center rounded-md border bg-card text-sm text-muted-foreground">
+              <div className="flex h-32 items-center justify-center rounded-md bg-secondary text-sm text-muted-foreground">
                 {connected
                   ? "Waiting for log events..."
                   : "Connecting to log stream..."}

--- a/packages/dashboard/src/app/logs/logs-content.tsx
+++ b/packages/dashboard/src/app/logs/logs-content.tsx
@@ -205,7 +205,7 @@ function SystemEventCard({ event }: { event: LogEvent }) {
       </div>
       <div
         className={cn(
-          "flex-1 rounded-lg bg-secondary p-3 font-mono text-xs",
+          "flex-1 rounded-lg border bg-secondary p-3 font-mono text-xs",
           event.level === "error" && "border-destructive/30",
           event.level === "warn" && "border-warning/30",
         )}
@@ -359,7 +359,7 @@ function RequestCard({
       </div>
       <div
         className={cn(
-          "flex-1 rounded-lg bg-secondary overflow-hidden",
+          "flex-1 rounded-lg border bg-secondary overflow-hidden",
           isError ? "border-destructive/30" : "border-border",
         )}
       >

--- a/packages/dashboard/src/app/logs/logs-stats.tsx
+++ b/packages/dashboard/src/app/logs/logs-stats.tsx
@@ -1008,7 +1008,7 @@ export function LogsStats({ events }: LogsStatsProps) {
       </div>
 
       {/* ── Mobile: collapsible strip above stream ── */}
-      <div className="lg:hidden shrink-0 rounded-lg border bg-card overflow-hidden">
+      <div className="lg:hidden shrink-0 rounded-lg bg-secondary overflow-hidden">
         <button
           type="button"
           onClick={() => setMobileExpanded(!mobileExpanded)}


### PR DESCRIPTION
Closes #24\n\nReplace misused bg-card (L1) with bg-secondary (L2) for content cards inside the floating island, per Basalt B05 spec.