### PR TITLE
fix(proxy): rewrite max_tokens → max_completion_tokens for Copilot gpt-5.4

### DIFF
--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -9,7 +9,7 @@
     "test:e2e": "bun test test/e2e/",
     "test:perf": "bun test test/perf/",
     "lint": "eslint --config ../../eslint.config.js --max-warnings=0 src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
     "gpt-tokenizer": "^3.0.1",

--- a/packages/proxy/src/protocols/translate/non-stream-translation.ts
+++ b/packages/proxy/src/protocols/translate/non-stream-translation.ts
@@ -165,6 +165,23 @@ function sanitizeSingleToolDefinition(tool: AnthropicTool): void {
 // Note: Server-side tool detection is now handled by preprocessPayload() in preprocess.ts.
 // The translation layer no longer tracks serverSideToolNames.
 
+// Copilot proxies `gpt-5.4` to OpenAI's reasoning-strict API, which rejects
+// `max_tokens` and requires `max_completion_tokens`. Older Copilot gpt-5.x
+// families (5.2, 5-mini) still accept `max_tokens`, so we narrow this rewrite
+// to 5.4+ families only. When future Copilot gpt-5.x families (5.5, 5.6, ...)
+// inherit the same strict behaviour, extend this regex.
+// Matches: gpt-5.4, gpt-5.4-codex, gpt-5.4-mini, ... (not gpt-5.2 / gpt-5-mini)
+const COPILOT_STRICT_MAX_COMPLETION_TOKENS_REGEX = /^gpt-5\.4(?:[-.]|$)/i
+
+function requiresMaxCompletionTokens(
+  targetFormat: TranslateTargetFormat | undefined,
+  translatedModel: string,
+): boolean {
+  if (targetFormat === "openai-reasoning") return true
+  if (targetFormat === "copilot" && COPILOT_STRICT_MAX_COMPLETION_TOKENS_REGEX.test(translatedModel)) return true
+  return false
+}
+
 /**
  * Target format for translation, determining how certain features are handled:
  * - "openai-reasoning": OpenAI upstream that supports reasoning_effort (o1/o3)
@@ -203,8 +220,10 @@ export function translateToOpenAI(
 
   // Build result with stable hidden-class shape (all optional fields included; undefined values
   // are skipped by JSON.stringify, so wire format matches the prior conditional-assignment version).
+  const translatedModel = translateModelName(payload.model, options?.anthropicBeta ?? null)
+  const useMaxCompletionTokens = requiresMaxCompletionTokens(options?.targetFormat, translatedModel)
   const result = {
-    model: translateModelName(payload.model, options?.anthropicBeta ?? null),
+    model: translatedModel,
     messages: translateAnthropicMessagesToOpenAI(
       payload.messages,
       payload.system ?? undefined,
@@ -213,7 +232,8 @@ export function translateToOpenAI(
         reorderToolResults: options?.reorderToolResults ?? false,
       },
     ),
-    max_tokens: payload.max_tokens,
+    max_tokens: useMaxCompletionTokens ? undefined : payload.max_tokens,
+    max_completion_tokens: useMaxCompletionTokens ? payload.max_tokens : undefined,
     stop,
     stream,
     temperature,

--- a/packages/proxy/test/translate/anthropic-to-openai.test.ts
+++ b/packages/proxy/test/translate/anthropic-to-openai.test.ts
@@ -1078,3 +1078,54 @@ describe("thinking → reasoning_effort", () => {
     expect(result.reasoning_effort).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// max_completion_tokens rewrite for gpt-5.4 on Copilot path
+// ---------------------------------------------------------------------------
+describe("translateToOpenAI — max_tokens → max_completion_tokens (Copilot gpt-5.4)", () => {
+  const mk = (model: string): AnthropicMessagesPayload =>
+    makeRequest({ model, max_tokens: 256 })
+
+  test("Copilot gpt-5.4: rewrites max_tokens → max_completion_tokens", () => {
+    const result = translateToOpenAI(mk("gpt-5.4"), { targetFormat: "copilot" })
+    expect(result.max_tokens).toBeUndefined()
+    expect(result.max_completion_tokens).toBe(256)
+  })
+
+  test("Copilot gpt-5.4-mini (and other 5.4 suffixed variants): rewrites", () => {
+    const result = translateToOpenAI(mk("gpt-5.4-mini"), { targetFormat: "copilot" })
+    expect(result.max_tokens).toBeUndefined()
+    expect(result.max_completion_tokens).toBe(256)
+  })
+
+  test("Copilot gpt-5.2: keeps legacy max_tokens (regression guard)", () => {
+    const result = translateToOpenAI(mk("gpt-5.2"), { targetFormat: "copilot" })
+    expect(result.max_tokens).toBe(256)
+    expect(result.max_completion_tokens).toBeUndefined()
+  })
+
+  test("Copilot gpt-5-mini: keeps legacy max_tokens", () => {
+    const result = translateToOpenAI(mk("gpt-5-mini"), { targetFormat: "copilot" })
+    expect(result.max_tokens).toBe(256)
+    expect(result.max_completion_tokens).toBeUndefined()
+  })
+
+  test("Copilot claude-*: keeps legacy max_tokens", () => {
+    const result = translateToOpenAI(mk("claude-opus-4.6"), { targetFormat: "copilot" })
+    expect(result.max_tokens).toBe(256)
+    expect(result.max_completion_tokens).toBeUndefined()
+  })
+
+  test("openai-reasoning always rewrites (unchanged behaviour)", () => {
+    const result = translateToOpenAI(mk("o3-mini"), { targetFormat: "openai-reasoning" })
+    expect(result.max_tokens).toBeUndefined()
+    expect(result.max_completion_tokens).toBe(256)
+  })
+
+  test("plain openai target: not affected by this fix (regression guard)", () => {
+    const result = translateToOpenAI(mk("gpt-5.4"), { targetFormat: "openai" })
+    // Custom-openai providers without supports_reasoning: no rewrite here.
+    expect(result.max_tokens).toBe(256)
+    expect(result.max_completion_tokens).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Copilot recently started proxying `gpt-5.4` to OpenAI's reasoning-strict API, which rejects `max_tokens` and returns `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`
- Narrow fix in `translateToOpenAI`: when `targetFormat === "copilot"` AND the model matches `/^gpt-5\.4(?:[-.]|$)/i`, send `max_completion_tokens` instead of `max_tokens`.
- Older Copilot gpt-5.x families (`gpt-5.2`, `gpt-5-mini`) still accept `max_tokens` — regex is intentionally narrow to avoid churning existing copilot-translated goldens.
- Also includes a small chore: `packages/proxy` `typecheck` script now uses `bunx tsc` so the pre-commit hook's PATH resolves correctly (dashboard was already fine via Next.js).

## Test plan

- ✅ Added 7 unit tests in `anthropic-to-openai.test.ts` covering gpt-5.4, gpt-5.4-mini, gpt-5.2 (regression), gpt-5-mini (regression), claude-* (regression), openai-reasoning (unchanged), and plain openai target (unchanged).
- ✅ Full proxy suite: 1611 pass / 0 fail.
- ✅ Lint + typecheck clean.
- ✅ End-to-end verified against live Copilot:
  - `gpt-5.4` → 200 OK (was 400 before)
  - `gpt-5.2`, `gpt-5-mini`, `claude-opus-4.6` → 200 OK (no regression)

## Out of scope

- `gpt-5.4-mini` fails with `unsupported_api_for_model` on `/chat/completions` — Copilot only exposes it via the Responses API. That's a separate routing concern, not a `max_tokens` issue.