### PR TITLE
style: fix HTML title language to match UI ("raven - Copilot Proxy Dashboard")

### DIFF
--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -20,12 +20,12 @@ export const metadata: Metadata = {
     process.env.NEXTAUTH_URL || "http://localhost:7023"
   ),
   title: {
-    default: "raven - Copilot 代理面板",
+    default: "raven - Copilot Proxy Dashboard",
     template: "%s - raven",
   },
   description: "GitHub Copilot proxy dashboard",
   openGraph: {
-    title: "raven - Copilot 代理面板",
+    title: "raven - Copilot Proxy Dashboard",
     description: "GitHub Copilot proxy dashboard",
     type: "website",
   },


### PR DESCRIPTION
Fix HTML title to use English to match the English-only UI.\n\nChanges title to: `raven - Copilot Proxy Dashboard`