### PR TITLE
fix: resolve translated model name against live Copilot catalog

### DIFF
--- a/packages/proxy/src/protocols/anthropic/preprocess.ts
+++ b/packages/proxy/src/protocols/anthropic/preprocess.ts
@@ -96,6 +96,21 @@ function translateModelNameUncached(model: string, anthropicBeta: string | null)
   return model
 }
 
+/**
+ * Catalog-aware resolution: if the translated name isn't in the live
+ * Copilot models catalog, try the `-internal` variant (some 1m/preview
+ * models ship under e.g. `claude-opus-4.7-1m-internal`). Falls back to
+ * the input name so behaviour is unchanged when catalog is empty or
+ * already contains the exact id.
+ */
+export function resolveAgainstCatalog(name: string, catalogIds: readonly string[]): string {
+  if (catalogIds.length === 0) return name
+  if (catalogIds.includes(name)) return name
+  const internalVariant = `${name}-internal`
+  if (catalogIds.includes(internalVariant)) return internalVariant
+  return name
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -234,11 +249,12 @@ export function detectServerTools(payload: AnthropicMessagesPayload): ServerTool
 export function preprocessPayload(
   rawPayload: AnthropicMessagesPayload,
   rawBeta: string | null,
+  catalogIds: readonly string[] = [],
 ): PreprocessedRequest {
   const rawModel = rawPayload.model
 
   // 1. Copilot model name normalization (only for Copilot path)
-  const copilotModel = translateModelName(rawModel, rawBeta)
+  const copilotModel = resolveAgainstCatalog(translateModelName(rawModel, rawBeta), catalogIds)
 
   // 2. Beta header filtering
   const anthropicBeta = filterAnthropicBeta(rawBeta)

--- a/packages/proxy/src/routes/messages/handler.ts
+++ b/packages/proxy/src/routes/messages/handler.ts
@@ -186,7 +186,7 @@ export async function handleCompletion(c: Context) {
   }
 
   // --- Preprocessing: normalize model name, filter beta, detect server tools ---
-  const preprocessed = preprocessPayload(anthropicPayload, anthropicBeta)
+  const preprocessed = preprocessPayload(anthropicPayload, anthropicBeta, state.models?.data?.map((m) => m.id) ?? [])
   const { payload: cleanedPayload, copilotModel, anthropicBeta: filteredBeta, serverToolContext } = preprocessed
 
   // --- Native Messages Routing ---
@@ -281,6 +281,9 @@ export async function handleCompletion(c: Context) {
     sanitizeOrphanedToolResults: state.optSanitizeOrphanedToolResults,
     reorderToolResults: state.optReorderToolResults,
   })
+  // Apply catalog-aware resolution (e.g. opus-4.7-1m → opus-4.7-1m-internal)
+  // so the outbound Copilot request uses the actual catalog id.
+  openAIPayload.model = copilotModel
 
   // Debug log if thinking was requested but dropped (Copilot doesn't support it)
   if (anthropicPayload.thinking?.type === "enabled") {

--- a/packages/proxy/test/routes/preprocess.test.ts
+++ b/packages/proxy/test/routes/preprocess.test.ts
@@ -5,6 +5,7 @@ import {
   sanitizePayload,
   detectServerTools,
   preprocessPayload,
+  resolveAgainstCatalog,
   ALLOWED_BETAS,
 } from "../../src/protocols/anthropic/preprocess"
 import type { AnthropicMessagesPayload } from "../../src/protocols/anthropic/types"
@@ -468,5 +469,46 @@ describe("preprocessPayload", () => {
     expect(result.serverToolContext.hasServerSideTools).toBe(true)
     expect(result.serverToolContext.allServerSide).toBe(false)
     expect(result.serverToolContext.serverSideToolNames).toEqual(["web_search"])
+  })
+})
+
+describe("resolveAgainstCatalog", () => {
+  test("returns input unchanged when catalog is empty (back-compat)", () => {
+    expect(resolveAgainstCatalog("claude-opus-4.7-1m", [])).toBe("claude-opus-4.7-1m")
+  })
+
+  test("returns input unchanged when catalog contains exact id", () => {
+    const catalog = ["claude-opus-4.6", "claude-opus-4.6-1m", "claude-opus-4.7"]
+    expect(resolveAgainstCatalog("claude-opus-4.6-1m", catalog)).toBe("claude-opus-4.6-1m")
+  })
+
+  test("resolves to -internal variant when only that exists in catalog", () => {
+    const catalog = ["claude-opus-4.7", "claude-opus-4.7-1m-internal"]
+    expect(resolveAgainstCatalog("claude-opus-4.7-1m", catalog)).toBe("claude-opus-4.7-1m-internal")
+  })
+
+  test("prefers exact match over -internal variant when both exist", () => {
+    const catalog = ["claude-opus-4.7-1m", "claude-opus-4.7-1m-internal"]
+    expect(resolveAgainstCatalog("claude-opus-4.7-1m", catalog)).toBe("claude-opus-4.7-1m")
+  })
+
+  test("returns input unchanged when neither exact nor -internal in catalog", () => {
+    const catalog = ["claude-opus-4.6", "claude-sonnet-4.5"]
+    expect(resolveAgainstCatalog("claude-opus-4.7-1m", catalog)).toBe("claude-opus-4.7-1m")
+  })
+})
+
+describe("preprocessPayload catalogIds threading", () => {
+  test("resolves copilotModel through catalog when -internal variant is present", () => {
+    const payload = makeRequest({ model: "claude-opus-4-7" })
+    const catalog = ["claude-opus-4.7", "claude-opus-4.7-1m-internal"]
+    const result = preprocessPayload(payload, "context-1m-2025-08-07", catalog)
+    expect(result.copilotModel).toBe("claude-opus-4.7-1m-internal")
+  })
+
+  test("default catalog (empty) preserves prior behaviour", () => {
+    const payload = makeRequest({ model: "claude-opus-4-7" })
+    const result = preprocessPayload(payload, "context-1m-2025-08-07")
+    expect(result.copilotModel).toBe("claude-opus-4.7-1m")
   })
 })


### PR DESCRIPTION
## Summary

The Copilot `/v1/models` endpoint sometimes exposes 1M / preview variants under an `-internal` suffix.

Concrete case I hit today on a Microsoft Copilot account:
- Catalog contains `claude-opus-4.7-1m-internal`
- Catalog does **not** contain `claude-opus-4.7-1m`

`translateModelName(\"claude-opus-4-7\", \"context-1m-2025-08-07\")` always emits `claude-opus-4.7-1m`, so the request is rejected upstream:

\`\`\`
400 {\"error\":{\"message\":\"The requested model is not supported.\",\"code\":\"model_not_supported\",...}}
\`\`\`

## Fix

New pure helper `resolveAgainstCatalog(name, catalogIds)`:
- if `catalogIds` is empty → return `name` (back-compat for callers that don't pass catalog)
- if `name` is in catalog → return `name` (the common case — no behaviour change for accounts where Copilot exposes the plain id)
- if `${name}-internal` is in catalog → return that
- else → return `name` (let upstream reject as before, so we don't mask other errors)

Threaded through:
- `preprocessPayload(..., catalogIds = [])` — new optional 3rd arg, defaults to `[]`
- `routes/messages/handler.ts` — passes `state.models?.data?.map(m => m.id) ?? []` and overrides `openAIPayload.model = copilotModel` on the translated-Copilot path so the resolved id is actually used on the wire

## Why this is safe for users who don't see `-internal` variants

The exact-match branch fires first. If your catalog has `claude-opus-4.7-1m` directly, this PR is a no-op for your traffic.

## Test plan

- [x] Existing 51 `preprocess.test.ts` tests still pass
- [x] 5 new cases on `resolveAgainstCatalog` (empty catalog, exact match, internal-only, both-present prefers-exact, neither-present)
- [x] 2 new cases on `preprocessPayload` catalog threading (with + without catalog)
- [x] `bun test packages/proxy/test/routes/preprocess.test.ts` → 56 pass
- [x] Typecheck clean
- [x] Pre-commit + pre-push gates pass (lint, typecheck, gitleaks, osv-scanner, coverage, arch)
- [x] Manually verified: `claude-cli` → opus-4.7 + 1M context beta now works end-to-end through raven against my Copilot account (previously 400)

## Open question for maintainer

Happy to narrow the heuristic if you'd prefer (e.g. only attempt `-internal` for known `-1m` suffixes) — current version is intentionally a generic fallback since the upstream naming may extend to other variants.