### PR TITLE
fix(proxy): support Codex MCP tools in Responses

### DIFF
--- a/packages/proxy/src/strategies/copilot-responses.ts
+++ b/packages/proxy/src/strategies/copilot-responses.ts
@@ -4,6 +4,12 @@
 // Promotes `routes/responses/handler.ts::copilotResponsesShim` onto the
 // canonical 7-method `Strategy` interface. Pure passthrough — no
 // translation. The composition root supplies the upstream client.
+//
+// `prepare` filters tool entries whose `type` is not accepted by Copilot
+// Responses. Codex MCP tools arrive as Responses `namespace` tools; Copilot
+// does not accept that wrapper, so Raven flattens namespace children and
+// matching function-call history into function tools before forwarding, then
+// restores the namespace on the way back.
 // ---------------------------------------------------------------------------
 
 import type { SSEMessage } from "hono/streaming"
@@ -30,6 +36,234 @@ export interface CopilotResponsesStreamState {
   resolvedModel: string
   inputTokens: number
   outputTokens: number
+  namespaceToolMapping?: NamespaceToolMapping
+}
+
+type NamespaceToolMapping = Map<string, { namespace: string; name: string }>
+
+const namespaceToolMappings = new WeakMap<ResponsesPayload, NamespaceToolMapping>()
+
+/**
+ * Tool types that the GitHub Copilot `/responses` endpoint accepts. Every
+ * other built-in tool (image_generation, code_interpreter, file_search,
+ * mcp, namespace, computer_use_preview, local_shell, ...) is rejected with
+ * `"The requested tool <type> is not supported."`. Codex CLI registers
+ * `image_generation` automatically on every request, so callers must be
+ * prepared to silently filter unsupported types. Namespace tools are handled
+ * specially before this allow-list is applied.
+ */
+export const COPILOT_SUPPORTED_TOOL_TYPES: ReadonlySet<string> = new Set([
+  "function",
+  "web_search_preview",
+])
+
+/**
+ * Convert Codex Responses tools into the subset accepted by Copilot. Namespace
+ * children are flattened using Codex's display name convention, e.g.
+ * `mcp__teams__` + `ListChats` => `mcp__teams__ListChats`.
+ */
+function prepareResponsesTools(req: ResponsesPayload): ResponsesPayload {
+  const tools = (req as { tools?: unknown }).tools
+  const namespaceMapping: NamespaceToolMapping = new Map()
+
+  let filteredTools: unknown[] | undefined
+  let toolsChanged = false
+  if (Array.isArray(tools)) {
+    const filtered: unknown[] = []
+    for (let i = 0; i < tools.length; i++) {
+      const tool = tools[i]
+      if (typeof tool !== "object" || tool === null) {
+        toolsChanged = true
+        continue
+      }
+
+      const toolType = (tool as { type?: unknown }).type
+      if (toolType === "namespace") {
+        toolsChanged = true
+        flattenNamespaceTool(tool as Record<string, unknown>, filtered, namespaceMapping)
+        continue
+      }
+
+      if (typeof toolType === "string" && COPILOT_SUPPORTED_TOOL_TYPES.has(toolType)) {
+        filtered.push(tool)
+      } else {
+        toolsChanged = true
+      }
+    }
+
+    if (toolsChanged && filtered.length > 0) filteredTools = filtered
+  }
+
+  const input = req.input
+  const rewrittenInput = flattenNamespacedInputFunctionCalls(input, namespaceMapping)
+  const inputChanged = rewrittenInput !== input
+
+  if (!toolsChanged && !inputChanged) return req
+
+  // Drop the field entirely when nothing remains; some upstreams treat
+  // `tools: []` as "force no tools" which is a different semantic from
+  // "tools field absent".
+  if (toolsChanged && filteredTools === undefined) {
+    const { tools: _omit, ...rest } = req as Record<string, unknown>
+    const prepared = {
+      ...rest,
+      ...(inputChanged ? { input: rewrittenInput } : {}),
+    } as ResponsesPayload
+    if (namespaceMapping.size > 0) namespaceToolMappings.set(prepared, namespaceMapping)
+    return prepared
+  }
+
+  const prepared = {
+    ...req,
+    ...(inputChanged ? { input: rewrittenInput } : {}),
+    ...(filteredTools ? { tools: filteredTools } : {}),
+  } as ResponsesPayload
+  if (namespaceMapping.size > 0) namespaceToolMappings.set(prepared, namespaceMapping)
+  return prepared
+}
+
+function flattenNamespaceTool(
+  tool: Record<string, unknown>,
+  out: unknown[],
+  mapping: NamespaceToolMapping,
+): void {
+  const namespace = tool.name
+  const children = tool.tools
+  if (typeof namespace !== "string" || !Array.isArray(children)) return
+
+  for (const child of children) {
+    if (typeof child !== "object" || child === null) continue
+    const childTool = child as Record<string, unknown>
+    if (childTool.type !== "function" || typeof childTool.name !== "string") continue
+
+    const flatName = `${namespace}${childTool.name}`
+    out.push({ ...childTool, name: flatName })
+    mapping.set(flatName, { namespace, name: childTool.name })
+  }
+}
+
+function flattenNamespacedInputFunctionCalls(
+  value: unknown,
+  mapping: NamespaceToolMapping,
+): unknown {
+  if (Array.isArray(value)) {
+    let changed = false
+    const next = value.map((item) => {
+      const rewritten = flattenNamespacedInputFunctionCalls(item, mapping)
+      if (rewritten !== item) changed = true
+      return rewritten
+    })
+    return changed ? next : value
+  }
+
+  if (typeof value !== "object" || value === null) return value
+
+  const record = value as Record<string, unknown>
+  const namespace = record.namespace
+  const name = record.name
+  const flatName = record.type === "function_call"
+    && typeof namespace === "string"
+    && typeof name === "string"
+    ? flattenNamespacedFunctionName(namespace, name, mapping)
+    : undefined
+
+  let changed = false
+  let next: Record<string, unknown> = record
+  if (flatName) {
+    const { namespace: _omit, ...rest } = record
+    next = { ...rest, name: flatName }
+    changed = true
+  }
+
+  for (const [key, child] of Object.entries(next)) {
+    const rewritten = flattenNamespacedInputFunctionCalls(child, mapping)
+    if (rewritten !== child) {
+      if (!changed) {
+        next = { ...next }
+        changed = true
+      }
+      next[key] = rewritten
+    }
+  }
+
+  return changed ? next : value
+}
+
+function flattenNamespacedFunctionName(
+  namespace: string,
+  name: string,
+  mapping: NamespaceToolMapping,
+): string {
+  for (const [flatName, mapped] of mapping) {
+    if (mapped.namespace === namespace && mapped.name === name) return flatName
+  }
+
+  if (name.startsWith(namespace)) return name
+  return `${namespace}${name}`
+}
+
+function restoreNamespacedFunctionCalls(
+  value: unknown,
+  mapping: NamespaceToolMapping | undefined,
+): unknown {
+  if (!mapping || mapping.size === 0) return value
+  return rewriteNamespacedFunctionCalls(value, mapping)
+}
+
+function rewriteNamespacedFunctionCalls(
+  value: unknown,
+  mapping: NamespaceToolMapping,
+): unknown {
+  if (Array.isArray(value)) {
+    let changed = false
+    const next = value.map((item) => {
+      const rewritten = rewriteNamespacedFunctionCalls(item, mapping)
+      if (rewritten !== item) changed = true
+      return rewritten
+    })
+    return changed ? next : value
+  }
+
+  if (typeof value !== "object" || value === null) return value
+
+  const record = value as Record<string, unknown>
+  const mapped = record.type === "function_call" && typeof record.name === "string"
+    ? mapping.get(record.name)
+    : undefined
+
+  let changed = false
+  let next: Record<string, unknown> = record
+  if (mapped) {
+    next = { ...record, name: mapped.name, namespace: mapped.namespace }
+    changed = true
+  }
+
+  for (const [key, child] of Object.entries(next)) {
+    const rewritten = rewriteNamespacedFunctionCalls(child, mapping)
+    if (rewritten !== child) {
+      if (!changed) {
+        next = { ...next }
+        changed = true
+      }
+      next[key] = rewritten
+    }
+  }
+
+  return changed ? next : value
+}
+
+function restoreNamespacedFunctionCallData(
+  data: string,
+  mapping: NamespaceToolMapping | undefined,
+): string {
+  if (!mapping || mapping.size === 0) return data
+  try {
+    const parsed = JSON.parse(data) as unknown
+    const rewritten = restoreNamespacedFunctionCalls(parsed, mapping)
+    return rewritten === parsed ? data : JSON.stringify(rewritten)
+  } catch {
+    return data
+  }
 }
 
 function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
@@ -48,7 +282,7 @@ export function makeCopilotResponses(deps: CopilotResponsesDeps): Strategy<
   return {
     name: "copilot-responses",
 
-    prepare: (req) => req,
+    prepare: (req) => prepareResponsesTools(req),
 
     dispatch: async (up) => {
       const response = await deps.client.send(up)
@@ -58,13 +292,20 @@ export function makeCopilotResponses(deps: CopilotResponsesDeps): Strategy<
       return { kind: "json", body: response }
     },
 
-    adaptJson: (resp) => resp,
+    adaptJson: (resp, req) => restoreNamespacedFunctionCalls(
+      resp,
+      namespaceToolMappings.get(req),
+    ),
 
-    initStreamState: (req) => ({
-      resolvedModel: req.model,
-      inputTokens: 0,
-      outputTokens: 0,
-    }),
+    initStreamState: (req) => {
+      const namespaceToolMapping = namespaceToolMappings.get(req)
+      return {
+        resolvedModel: req.model,
+        inputTokens: 0,
+        outputTokens: 0,
+        ...(namespaceToolMapping ? { namespaceToolMapping } : {}),
+      }
+    },
 
     adaptChunk: (chunk, st, ctx) => {
       emitUpstreamRawSse(ctx.requestId, { event: chunk.event, data: chunk.data })
@@ -82,7 +323,8 @@ export function makeCopilotResponses(deps: CopilotResponsesDeps): Strategy<
         }
       }
 
-      const sseMsg: SSEMessage = { data: chunk.data }
+      const data = restoreNamespacedFunctionCallData(chunk.data, st.namespaceToolMapping)
+      const sseMsg: SSEMessage = { data }
       if (chunk.event) sseMsg.event = chunk.event
       if (chunk.id) sseMsg.id = chunk.id
       if (chunk.retry !== null) sseMsg.retry = chunk.retry

--- a/packages/proxy/test/strategies/copilot-responses-tool-filter.test.ts
+++ b/packages/proxy/test/strategies/copilot-responses-tool-filter.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Regression tests for the Codex CLI <-> Copilot Responses API tool gap.
+ *
+ * mai-agents reference: litellm_patches/responses/litellm_completion_transformation/handler.py
+ *   GithubCopilotResponsesAPIConfig._SUPPORTED_TOOL_TYPES = {"function", "web_search_preview"}
+ *
+ *   "Codex CLI registers built-in tools like image_generation on every
+ *    request, so we must strip them before forwarding to Copilot.
+ *    Otherwise: 'The requested tool <type> is not supported.'"
+ *
+ * Desired: strategy.prepare strips every unsupported tool type, leaves
+ * `function` and `web_search_preview` untouched, and flattens Codex MCP
+ * `namespace` tools into function tools that Copilot Responses accepts.
+ */
+import { describe, expect, test } from "vitest"
+
+import { makeCopilotResponses } from "../../src/strategies/copilot-responses"
+import type { RequestContext } from "../../src/core/context"
+import type {
+  CopilotResponsesClient,
+  ResponsesPayload,
+} from "../../src/upstream/copilot-responses"
+
+function makeCtx(): RequestContext {
+  return {
+    requestId: "01TESTRESPONSESCOMPAT0000",
+    startTime: performance.now(),
+    format: "responses",
+    path: "/v1/responses",
+    stream: false,
+    accountName: "acct",
+    userAgent: null,
+    anthropicBeta: null,
+    sessionId: "sess",
+    clientName: "Codex",
+    clientVersion: null,
+  }
+}
+
+const noopClient = { send: async () => ({}) } as unknown as CopilotResponsesClient
+
+function asTools(prepared: ResponsesPayload): Array<Record<string, unknown>> {
+  const tools = (prepared as Record<string, unknown>).tools
+  if (tools == null) return []
+  if (!Array.isArray(tools)) throw new Error("tools must be an array (or null)")
+  return tools as Array<Record<string, unknown>>
+}
+
+describe("Gap 3: Codex Responses tool type filtering", () => {
+  test("strips image_generation tools that Copilot rejects", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools: [
+        { type: "image_generation" },
+        { type: "function", name: "shell", parameters: {} },
+      ],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    const tools = asTools(out)
+
+    expect(tools.map((t) => t.type)).toEqual(["function"])
+  })
+
+  test("strips multiple unsupported tool types in one request", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools: [
+        { type: "image_generation" },
+        { type: "code_interpreter" },
+        { type: "file_search" },
+        { type: "mcp" },
+        { type: "computer_use_preview" },
+        { type: "local_shell" },
+        { type: "function", name: "shell", parameters: {} },
+        { type: "web_search_preview" },
+      ],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    const tools = asTools(out)
+    const types = tools.map((t) => t.type).sort()
+    expect(types).toEqual(["function", "web_search_preview"])
+  })
+
+  test("flattens namespace tools into function tools", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__teams__",
+          description: "Teams MCP tools",
+          tools: [
+            {
+              type: "function",
+              name: "ListChats",
+              description: "List chats",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    const tools = asTools(out)
+
+    expect(tools).toHaveLength(1)
+    expect(tools[0]).toMatchObject({
+      type: "function",
+      name: "mcp__teams__ListChats",
+      description: "List chats",
+      parameters: { type: "object", properties: {} },
+    })
+  })
+
+  test("restores flattened namespace function calls in JSON responses", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__workiq__",
+          tools: [{ type: "function", name: "ask_work_iq", parameters: {} }],
+        },
+      ],
+    } as unknown as ResponsesPayload
+    const prepared = s.prepare(req, makeCtx())
+    const resp = {
+      id: "resp_1",
+      output: [
+        {
+          type: "function_call",
+          name: "mcp__workiq__ask_work_iq",
+          arguments: "{}",
+          call_id: "call_1",
+        },
+      ],
+    }
+
+    const out = s.adaptJson(resp, prepared, makeCtx()) as typeof resp
+
+    expect(out.output[0]).toMatchObject({
+      type: "function_call",
+      namespace: "mcp__workiq__",
+      name: "ask_work_iq",
+      call_id: "call_1",
+    })
+    expect(resp.output[0]!.name).toBe("mcp__workiq__ask_work_iq")
+  })
+
+  test("restores flattened namespace function calls in stream chunks", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      stream: true,
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__teams__",
+          tools: [{ type: "function", name: "ListChats", parameters: {} }],
+        },
+      ],
+    } as unknown as ResponsesPayload
+    const prepared = s.prepare(req, makeCtx())
+    const state = s.initStreamState(prepared, makeCtx())
+    const out = s.adaptChunk(
+      {
+        event: "response.output_item.done",
+        data: JSON.stringify({
+          item: {
+            type: "function_call",
+            name: "mcp__teams__ListChats",
+            arguments: "{}",
+            call_id: "call_2",
+          },
+        }),
+        id: null,
+        retry: null,
+      },
+      state,
+      makeCtx(),
+    )
+
+    const parsed = JSON.parse(String(out[0]!.data))
+    expect(parsed.item).toMatchObject({
+      type: "function_call",
+      namespace: "mcp__teams__",
+      name: "ListChats",
+      call_id: "call_2",
+    })
+  })
+
+  test("flattens namespaced function_call history in request input", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const functionCall = {
+      type: "function_call",
+      namespace: "mcp__teams__",
+      name: "ListChats",
+      arguments: "{}",
+      call_id: "call_3",
+    }
+    const input = [
+      { role: "user", content: "show my chats" },
+      functionCall,
+      { type: "function_call_output", call_id: "call_3", output: "[]" },
+    ]
+    const req = {
+      model: "gpt-5.5",
+      input,
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__teams__",
+          tools: [{ type: "function", name: "ListChats", parameters: {} }],
+        },
+      ],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    const outInput = (out as Record<string, unknown>).input as Array<Record<string, unknown>>
+
+    expect(outInput).not.toBe(input)
+    expect(outInput[1]).toMatchObject({
+      type: "function_call",
+      name: "mcp__teams__ListChats",
+      arguments: "{}",
+      call_id: "call_3",
+    })
+    expect(outInput[1]).not.toHaveProperty("namespace")
+    expect(functionCall).toMatchObject({
+      namespace: "mcp__teams__",
+      name: "ListChats",
+    })
+  })
+
+  test("flattens namespaced function_call history without current tool definitions", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const functionCall = {
+      type: "function_call",
+      namespace: "mcp__workiq__",
+      name: "ask_work_iq",
+      arguments: "{}",
+      call_id: "call_4",
+    }
+    const req = {
+      model: "gpt-5.5",
+      input: [functionCall],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    const outInput = (out as Record<string, unknown>).input as Array<Record<string, unknown>>
+
+    expect(outInput[0]).toMatchObject({
+      type: "function_call",
+      name: "mcp__workiq__ask_work_iq",
+      call_id: "call_4",
+    })
+    expect(outInput[0]).not.toHaveProperty("namespace")
+    expect(functionCall.name).toBe("ask_work_iq")
+    expect(functionCall.namespace).toBe("mcp__workiq__")
+  })
+
+  test("preserves function tool definitions untouched", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const fn = {
+      type: "function",
+      name: "shell",
+      description: "run shell",
+      parameters: { type: "object", properties: { cmd: { type: "string" } } },
+    }
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools: [fn],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    const tools = asTools(out)
+    expect(tools).toHaveLength(1)
+    expect(tools[0]).toEqual(fn)
+  })
+
+  test("preserves web_search_preview tools (Copilot supports them)", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools: [{ type: "web_search_preview" }],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    const tools = asTools(out)
+    expect(tools).toHaveLength(1)
+    expect(tools[0]!.type).toBe("web_search_preview")
+  })
+
+  test("when all tools are unsupported, tools field is removed (not left empty)", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools: [{ type: "image_generation" }, { type: "code_interpreter" }],
+    } as unknown as ResponsesPayload
+
+    const out = s.prepare(req, makeCtx())
+    // After filtering everything out we must NOT send an empty tools array,
+    // since some upstreams interpret "tools: []" as "force no tools".
+    // Either omit the key entirely or set it to undefined / null.
+    const tools = (out as Record<string, unknown>).tools
+    expect(tools == null || (Array.isArray(tools) && tools.length === 0)).toBe(true)
+    if (Array.isArray(tools)) expect(tools).toHaveLength(0)
+  })
+
+  test("requests without a tools field are passed through unchanged", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const req = { model: "gpt-5.5", input: "hi" } as unknown as ResponsesPayload
+    const out = s.prepare(req, makeCtx())
+    expect((out as Record<string, unknown>).tools).toBeUndefined()
+  })
+
+  test("prepare does not mutate the caller's payload", () => {
+    const s = makeCopilotResponses({ client: noopClient })
+    const tools = [
+      { type: "image_generation" },
+      {
+        type: "namespace",
+        name: "mcp__teams__",
+        tools: [{ type: "function", name: "ListChats", parameters: {} }],
+      },
+      { type: "function", name: "shell", parameters: {} },
+    ]
+    const req = {
+      model: "gpt-5.5",
+      input: "hi",
+      tools,
+    } as unknown as ResponsesPayload
+
+    s.prepare(req, makeCtx())
+    // Caller's array must still hold the original entries.
+    expect(tools.map((t) => t.type)).toEqual([
+      "image_generation",
+      "namespace",
+      "function",
+    ])
+    const namespaceTool = tools[1] as { tools: Array<{ name: string }> }
+    expect(namespaceTool.tools[0]!.name).toBe("ListChats")
+  })
+})


### PR DESCRIPTION
## Summary
This fixes the Codex CLI -> Raven -> GitHub Copilot Responses compatibility gap for MCP tools. Codex is expected to use the OpenAI Responses API (`/v1/responses`) when configured with `wire_api = "responses"`, but its tool payload can include shapes that Copilot Responses does not accept directly.

## Problem
Before this change, Raven forwarded `/v1/responses` payloads to Copilot mostly as-is. That breaks Codex MCP usage in two related ways:

- Codex may include tool types that Copilot Responses rejects, such as `image_generation`, `code_interpreter`, `file_search`, `mcp`, `computer_use_preview`, and `local_shell`.
- Codex represents MCP servers as Responses `namespace` tools, for example `mcp__teams__` with child function tools like `ListChats`. Copilot does not support `type: "namespace"`, so forwarding these definitions unchanged can fail with unsupported-tool errors.
- MCP tool calls also need to round-trip correctly. If Raven only flattened the request but did not restore response function calls and next-turn history, Codex would not be able to route the tool call back to the right MCP namespace.

## Fix
- Filter `/v1/responses` tools down to the tool types Copilot accepts: `function` and `web_search_preview`.
- Flatten Codex MCP `namespace` tool definitions into Copilot-compatible function tools, e.g. `mcp__teams__` + `ListChats` becomes `mcp__teams__ListChats`.
- Keep a per-request mapping from flattened function names back to `{ namespace, name }`.
- Restore flattened MCP function calls in both non-streaming JSON responses and streaming SSE chunks before returning them to Codex.
- Flatten namespaced `function_call` entries in next-turn `input` history so MCP tool-result continuations remain consistent when sent back upstream.

## Behavior after this PR
Codex can continue using the correct Raven provider configuration with `wire_api = "responses"`. MCP tools sent through the Responses API are normalized for Copilot on the upstream side and restored to Codex's expected namespace shape on the client side.

## Testing
- `bunx --bun vitest run packages/proxy/test/strategies/copilot-responses-tool-filter.test.ts packages/proxy/test/strategies/copilot-responses.test.ts packages/proxy/test/translate/upstream-compat-gaps.test.ts packages/proxy/test/routes/preprocess.test.ts packages/proxy/test/routes/messages-handler.test.ts packages/proxy/test/core/router.test.ts`
- `bun run --filter @raven/proxy typecheck`
- `bun run --filter @raven/proxy lint`
- `bun run scripts/gate-security.ts`
- `git push` pre-push gates: security, coverage, arch passed
