### PR TITLE
test(proxy): stub version detection in settings.test to fix CI timeout

### DIFF
--- a/packages/proxy/test/routes/settings.test.ts
+++ b/packages/proxy/test/routes/settings.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import { Database } from "bun:sqlite";
-import { createSettingsRoute } from "../../src/routes/settings.ts";
-import { initSettings, getSetting, setSetting } from "../../src/db/settings.ts";
-import { cacheServerTools, cacheIPWhitelist, cacheOptimizations, cacheSoundSettings } from "../../src/lib/utils.ts";
-import { state } from "../../src/lib/state.ts";
+
+// Stub the local-detection and AUR-fetch helpers that cacheVersions() awaits.
+// Without these, PUT/DELETE /settings handlers reach out to the network
+// (AUR pkgbuild) and the filesystem (~/.vscode/extensions), which races
+// vitest's default 5s test timeout on slow CI runners and trips
+// "Cannot use a closed database" when the deferred work outlives afterEach.
+vi.mock("../../src/services/get-vscode-version", () => ({
+  getVSCodeVersion: () => Promise.resolve(undefined),
+}));
+vi.mock("../../src/services/detect-local-versions", () => ({
+  detectLocalVSCodeVersion: () => Promise.resolve(null),
+  detectLocalCopilotVersion: () => Promise.resolve(null),
+}));
+
+const { createSettingsRoute } = await import("../../src/routes/settings.ts");
+const { initSettings, getSetting, setSetting } = await import("../../src/db/settings.ts");
+const { cacheServerTools, cacheIPWhitelist, cacheOptimizations, cacheSoundSettings } = await import("../../src/lib/utils.ts");
+const { state } = await import("../../src/lib/state.ts");
 
 let db: Database;
 


### PR DESCRIPTION
## Summary

- Tracks [STU-405](https://github.com/nocoo/raven) — CI failure on `main` (run 27250025263) where L1 Coverage gate and L2 settings test both went red after PR #84.
- Root cause: `packages/proxy/test/routes/settings.test.ts > version settings > sets copilot_chat_version with valid semver` PUTs a version key, which makes the route handler `await cacheVersions(db)`. `cacheVersions` fetches `aur.archlinux.org` (5s AbortController) and scans `~/.vscode/extensions` for the Copilot Chat extension. On CI those calls race vitest's default 5s test timeout — the test reports a timeout, but the still-running promise outlives the `afterEach` that calls `db.close()`, surfacing as `RangeError: Cannot use a closed database` from `getSetting(db, "copilot_chat_version")`. That uncaught rejection also poisoned the L1 Coverage gate run in the same process.
- Fix: `vi.mock` `src/services/get-vscode-version` and `src/services/detect-local-versions` in the settings route test so `cacheVersions` becomes fast and deterministic — no network, no FS. These modules already have dedicated unit coverage in `test/services/detect-local-versions.test.ts`. No production code is touched; no `testTimeout` bump.

## Test plan

- [x] `bunx --bun vitest run test/routes/settings.test.ts` — 49 passed in ~31ms (was ~3.2s; timeout on CI)
- [x] `bun run test:l2` — 27 files / 437 tests passed
- [x] `bun run scripts/check-coverage.ts` — Coverage gate passed (98.48% lines vs floor 97.50%; L1 tests 1696 vs baseline 1674)
- [ ] CI green on this PR