### PR TITLE
chore(deps): upgrade @types/node to 25.9.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "@types/react": "19.2.17",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^6.0.1",
@@ -521,7 +521,7 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,7 +31,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^6.0.1",


### PR DESCRIPTION
## Summary

- `packages/dashboard`: bump `@types/node` `25.9.2` → `25.9.3` (devDependencies, patch)
- Single atomic commit, lockfile in sync

Closes #86

## Test plan

- [x] `bun run typecheck` (packages/dashboard)
- [x] `bun run test` — 26 files / 368 tests (packages/dashboard)
- [x] Repo root `bun run test:all` — dashboard 26/368 + proxy 113/1696 (verified by reviewer)
- [x] `bun run scripts/check-fetch-boundary.ts`
- [x] Pre-commit gates: tests / lint-staged / typecheck / fetch-boundary / gitleaks