### PR TITLE
fix(dashboard): reset create-key dialog state on every open

### DIFF
--- a/packages/dashboard/src/app/connect/connect-content.tsx
+++ b/packages/dashboard/src/app/connect/connect-content.tsx
@@ -457,8 +457,18 @@ function ModelGroup({ vendor, models }: { vendor: string; models: ModelInfo[] })
 function ApiKeysSection({ keys: initialKeys }: { keys: ApiKeyPublic[] }) {
   const router = useRouter();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogInstance, setDialogInstance] = useState(0);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+
+  // Remount CreateKeyDialog on every open so its internal state (name input,
+  // createdKey, error) starts fresh. Without this, the previous createdKey
+  // sticks and the second open skips the name prompt while re-showing the
+  // stale key — no new key is actually created.
+  const handleOpenChange = useCallback((open: boolean) => {
+    setDialogOpen(open);
+    if (open) setDialogInstance((n) => n + 1);
+  }, []);
 
   const handleCreated = useCallback(() => {
     setDialogOpen(false);
@@ -499,14 +509,14 @@ function ApiKeysSection({ keys: initialKeys }: { keys: ApiKeyPublic[] }) {
             Create and manage API keys for authenticating client requests
           </p>
         </div>
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <Dialog open={dialogOpen} onOpenChange={handleOpenChange}>
           <DialogTrigger asChild>
             <Button size="sm" variant="outline" className="gap-1.5">
               <Plus className="h-3.5 w-3.5" strokeWidth={1.5} />
               Create Key
             </Button>
           </DialogTrigger>
-          <CreateKeyDialog onCreated={handleCreated} />
+          <CreateKeyDialog key={dialogInstance} onCreated={handleCreated} />
         </Dialog>
       </div>
 

--- a/packages/dashboard/test/components/connect-content.test.tsx
+++ b/packages/dashboard/test/components/connect-content.test.tsx
@@ -314,4 +314,39 @@ describe("CreateKeyDialog", () => {
       expect(screen.getByText("Failed to create key")).toBeDefined();
     });
   });
+
+  it("re-opening dialog after a successful create resets to the name-input view", async () => {
+    // First create succeeds and surfaces the key.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: "1", key: "rk-first-key" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    renderWithDialog();
+    const user = await openDialog();
+
+    let input = screen.getByPlaceholderText(/cursor-mbp/i);
+    await user.type(input, "first-key");
+    await user.click(screen.getByRole("button", { name: /^Create$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("rk-first-key")).toBeDefined();
+    });
+
+    // Close (Done) and re-open: dialog must prompt for a fresh name, not
+    // re-display the stale created-key view.
+    await user.click(screen.getByRole("button", { name: /Done/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("rk-first-key")).toBeNull();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Create Key/i }));
+
+    input = await screen.findByPlaceholderText(/cursor-mbp/i);
+    expect((input as HTMLInputElement).value).toBe("");
+    expect(screen.queryByText("rk-first-key")).toBeNull();
+  });
 });


### PR DESCRIPTION
Relates to [STU-557](mention://issue/fe48e6cd-17c2-4f7d-84d0-304911b6c57b).

## Summary
- `CreateKeyDialog` lived inside `<Dialog>` and kept its internal state (`name` / `createdKey` / `error`) across open/close cycles. After a successful first create, `createdKey` persisted so re-opening the dialog jumped straight to the "Key Created" view re-displaying the **previous** key — no name prompt, no second POST. That also explained the "list doesn't update on refresh" report: no new key was ever created.
- Bumped a `dialogInstance` counter on every open and pass it as `key` to `CreateKeyDialog`, forcing a fresh remount with clean state.

## Test plan
- [x] Unit: `bunx --bun vitest run packages/dashboard/test/components/connect-content.test.tsx` — 11/11 pass, including new regression `re-opening dialog after a successful create resets to the name-input view`.
- [x] Dashboard suite: `bun run --filter dashboard test` — 369/369 pass.
- [x] `bun run --filter dashboard typecheck` clean.
- [x] `bun run --filter dashboard lint` clean (0 warnings).
- [x] Pre-commit + pre-push gates all green.