### PR TITLE
chore(deps): upgrade lucide-react 1.18.0 → 1.20.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.18.0",
+        "lucide-react": "1.20.0",
         "next": "16.2.9",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "1.6.0",
@@ -1092,7 +1092,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
+    "lucide-react": ["lucide-react@1.20.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.18.0",
+    "lucide-react": "1.20.0",
     "next": "16.2.9",
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "1.6.0",


### PR DESCRIPTION
## Summary

Upgrade `lucide-react` from `1.18.0` to `1.20.0` in `packages/dashboard` (minor bump).

## Changes

- `packages/dashboard/package.json`: `lucide-react` `1.18.0` → `1.20.0`
- `bun.lock`: resolved to `lucide-react@1.20.0`

## Verification

- ✅ dashboard typecheck
- ✅ dashboard unit tests (368 tests, Statements 90.64% ≥ 90% threshold)
- ✅ dashboard build
- ✅ `gate:security` (osv-scanner + gitleaks)
- ✅ Bun frozen install reproducible; license ISC; React 19 peer range satisfied

Closes #103