### PR TITLE
fix(proxy): resolve 1m context models against live Copilot catalog

### DIFF
--- a/packages/proxy/src/core/router.ts
+++ b/packages/proxy/src/core/router.ts
@@ -8,7 +8,7 @@
 // the composition root (§3.8).
 
 import type { CompiledProvider } from "../db/providers"
-import { translateModelName } from "../protocols/anthropic/preprocess"
+import { resolveAgainstCatalog, translateModelName } from "../protocols/anthropic/preprocess"
 
 export type StrategyName =
   | "copilot-native"
@@ -107,6 +107,7 @@ export function pickStrategy(input: RouterInput): StrategyDecision {
 
   if (protocol === "anthropic") {
     const normalisedModel = translateModelName(model, anthropicBeta ?? null)
+    const catalogModel = resolveAgainstCatalog(normalisedModel, modelsCatalogIds)
     const candidates =
       normalisedModel !== model ? [model, normalisedModel] : [model]
     const matched = matchProvider(candidates, providers)
@@ -117,7 +118,7 @@ export function pickStrategy(input: RouterInput): StrategyDecision {
           : "custom-openai"
       return { kind: "ok", name, providerId: matched.provider.id }
     }
-    if (nativeSupported(normalisedModel, modelsCatalogIds)) {
+    if (nativeSupported(catalogModel, modelsCatalogIds)) {
       return { kind: "ok", name: "copilot-native" }
     }
     return { kind: "ok", name: "copilot-translated" }

--- a/packages/proxy/src/lib/token.ts
+++ b/packages/proxy/src/lib/token.ts
@@ -6,6 +6,7 @@ import { getCopilotToken } from "./../services/github/get-copilot-token"
 import { getDeviceCode } from "./../services/github/get-device-code"
 import { getGitHubUser } from "./../services/github/get-user"
 import { pollAccessToken } from "./../services/github/poll-access-token"
+import { cacheModels } from "./utils"
 
 import { HTTPError } from "./error"
 import { state } from "./state"
@@ -61,6 +62,7 @@ function scheduleTokenRefresh(
       const { token, refresh_in } = await getCopilotToken()
       state.copilotToken = token
       logger.debug("Copilot token refreshed")
+      await refreshModelsForToken()
 
       // If upstream changed refresh_in, reschedule with new interval
       const newIntervalMs = Math.max((refresh_in - 60) * 1000, MIN_REFRESH_MS)
@@ -97,6 +99,7 @@ function retryTokenRefresh(
       const { token, refresh_in } = await getCopilotToken()
       state.copilotToken = token
       logger.info("Copilot token recovered after retry")
+      await refreshModelsForToken()
       // Success — resume normal refresh schedule
       scheduleTokenRefresh(refresh_in, timers)
     } catch (retryError) {
@@ -105,6 +108,16 @@ function retryTokenRefresh(
       retryTokenRefresh(nextBackoff, originalRefreshInSeconds, retryError, timers)
     }
   }, backoff)
+}
+
+async function refreshModelsForToken(): Promise<void> {
+  try {
+    await cacheModels()
+  } catch (error) {
+    logger.warn("Failed to refresh models after Copilot token refresh", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }
 
 interface SetupGitHubTokenOptions {

--- a/packages/proxy/src/protocols/anthropic/preprocess.ts
+++ b/packages/proxy/src/protocols/anthropic/preprocess.ts
@@ -97,17 +97,30 @@ function translateModelNameUncached(model: string, anthropicBeta: string | null)
 }
 
 /**
- * Catalog-aware resolution: if the translated name isn't in the live
- * Copilot models catalog, try the `-internal` variant (some 1m/preview
- * models ship under e.g. `claude-opus-4.7-1m-internal`). Falls back to
- * the input name so behaviour is unchanged when catalog is empty or
- * already contains the exact id.
+ * Catalog-aware resolution: reconcile a generated Copilot model id against
+ * the live models catalog.
+ *
+ * Resolution order (first hit wins):
+ * 1. Exact id present in catalog → use as-is.
+ * 2. `-internal` variant present (some preview/1m SKUs historically shipped
+ *    under e.g. `claude-opus-4.7-1m-internal`) → use that.
+ * 3. A `-1m` id whose base model is in the catalog → fall back to the base.
+ *    Copilot folded the 1M context window into the base models and retired
+ *    the standalone `-1m` / `-1m-internal` SKUs, so `claude-opus-4.7-1m`
+ *    must resolve to `claude-opus-4.7` (which now serves 1M by default).
+ *
+ * Falls back to the input name so behaviour is unchanged when the catalog is
+ * empty or already contains the exact id.
  */
 export function resolveAgainstCatalog(name: string, catalogIds: readonly string[]): string {
   if (catalogIds.length === 0) return name
   if (catalogIds.includes(name)) return name
   const internalVariant = `${name}-internal`
   if (catalogIds.includes(internalVariant)) return internalVariant
+  if (name.endsWith("-1m")) {
+    const base = name.slice(0, -3)
+    if (catalogIds.includes(base)) return base
+  }
   return name
 }
 

--- a/packages/proxy/test/core/router.test.ts
+++ b/packages/proxy/test/core/router.test.ts
@@ -84,6 +84,17 @@ describe("pickStrategy — branch coverage assertions", () => {
     expect(decision).toEqual({ kind: "ok", name: "copilot-native" })
   })
 
+  test("anthropic with context-1m beta uses catalog internal alias for native routing", () => {
+    const decision = pickStrategy({
+      protocol: "anthropic",
+      model: "claude-opus-4-7",
+      anthropicBeta: "context-1m-2025-08-07",
+      providers: [],
+      modelsCatalogIds: ["claude-opus-4.7", "claude-opus-4.7-1m-internal"],
+    })
+    expect(decision).toEqual({ kind: "ok", name: "copilot-native" })
+  })
+
   test("anthropic exact-on-raw beats glob-on-normalised within candidate order", () => {
     // raw matches an exact pattern; normalised would only hit a glob.
     // Per resolveProviderForModels, exact pass beats glob pass globally.

--- a/packages/proxy/test/lib/token.test.ts
+++ b/packages/proxy/test/lib/token.test.ts
@@ -7,6 +7,8 @@ import { state } from "../../src/lib/state"
 import { HTTPError } from "../../src/lib/error"
 import type { TimerFactory } from "../../src/lib/token"
 
+const cacheModelsMock = vi.fn()
+
 // ---------------------------------------------------------------------------
 // Mock ~/lib/paths to redirect token file to temp dir.
 // This module is not imported by any other test file → no poisoning risk.
@@ -31,6 +33,12 @@ vi.mock("../../src/lib/paths", () => ({
   },
 }))
 
+vi.mock("../../src/lib/utils", () => ({
+  cacheModels: cacheModelsMock,
+  sleep: () => Promise.resolve(),
+  isNullish: (v: unknown) => v === null || v === undefined,
+}))
+
 // Import AFTER mock is registered
 const { setupGitHubToken, setupCopilotToken } = await import("../../src/lib/token")
 
@@ -47,6 +55,7 @@ beforeEach(() => {
   state.copilotToken = null
   state.vsCodeVersion = "1.90.0"
   state.accountType = "individual"
+  cacheModelsMock.mockReset()
   fetchSpy = vi.spyOn(globalThis, "fetch")
 })
 
@@ -251,6 +260,19 @@ describe("setupCopilotToken", () => {
     expect(state.copilotToken).toBe("copilot-jwt-refreshed")
     // Original timer still active (same interval)
     expect(fakeTimers.timers[0]!.cleared).toBe(false)
+  })
+
+  test("refresh success: refreshes cached models for the new token", async () => {
+    const fakeTimers = createFakeTimers()
+    mockCopilotTokenResponse("copilot-jwt", 1500)
+    await setupCopilotToken(fakeTimers)
+
+    cacheModelsMock.mockClear()
+    mockCopilotTokenResponse("copilot-jwt-refreshed", 1500)
+    await fakeTimers.tick(fakeTimers.timers[0]!.id)
+
+    expect(state.copilotToken).toBe("copilot-jwt-refreshed")
+    expect(cacheModelsMock).toHaveBeenCalledTimes(1)
   })
 
   test("refresh with changed refresh_in: reschedules with new interval", async () => {

--- a/packages/proxy/test/routes/preprocess.test.ts
+++ b/packages/proxy/test/routes/preprocess.test.ts
@@ -492,6 +492,17 @@ describe("resolveAgainstCatalog", () => {
     expect(resolveAgainstCatalog("claude-opus-4.7-1m", catalog)).toBe("claude-opus-4.7-1m")
   })
 
+  test("falls back to base model when -1m retired but base is in catalog", () => {
+    // Copilot folded 1M context into the base model and dropped the -1m SKU.
+    const catalog = ["claude-opus-4.7", "claude-sonnet-4.6"]
+    expect(resolveAgainstCatalog("claude-opus-4.7-1m", catalog)).toBe("claude-opus-4.7")
+  })
+
+  test("prefers exact -1m over base fallback when -1m still exists", () => {
+    const catalog = ["claude-opus-4.7", "claude-opus-4.7-1m"]
+    expect(resolveAgainstCatalog("claude-opus-4.7-1m", catalog)).toBe("claude-opus-4.7-1m")
+  })
+
   test("returns input unchanged when neither exact nor -internal in catalog", () => {
     const catalog = ["claude-opus-4.6", "claude-sonnet-4.5"]
     expect(resolveAgainstCatalog("claude-opus-4.7-1m", catalog)).toBe("claude-opus-4.7-1m")


### PR DESCRIPTION
## Summary

Copilot folded the 1M context window into the base `claude-*` models and retired the standalone `-1m` / `-1m-internal` SKUs. The proxy still appended `-1m` (from the `context-1m` beta header or `[1m]` / `-1m` model suffixes), producing ids like `claude-opus-4.7-1m` that no longer exist in the catalog — causing **400 `model_not_supported`** on `claude-cli` context-1m requests.

## Changes

- **preprocess** (`protocols/anthropic/preprocess.ts`): `resolveAgainstCatalog` now falls back from a retired `-1m` id to its base model when the base is present in the live catalog. Exact `-1m` / `-internal` matches still win first, preserving forward-compat if the SKUs ever return.
- **router** (`core/router.ts`): `pickStrategy` routes on the catalog-resolved id, so native eligibility is judged against the real model.
- **token** (`lib/token.ts`): refresh the models catalog after each Copilot token refresh so it never goes stale/empty between the hourly refresh window.

## Test plan

- [x] `bun run test` — proxy unit tests pass (3 new tests added: `router.test.ts`, `token.test.ts`, `preprocess.test.ts`)
- [x] `tsc --noEmit` + eslint clean
- [ ] Manual: `claude-cli` with `context-1m` beta no longer returns 400 `model_not_supported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
