### PR TITLE
chore(ci): pin base-ci reusable workflow to v2026.5 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 # but runs in parallel with the local arch + coverage-gate jobs.
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
     with:
       bun-version: "1.3.11"
       test-command: "bun run test:all"


### PR DESCRIPTION
## Summary

Pin the `nocoo/base-ci` reusable workflow reference from the floating tag `@v2026.4` to the immutable commit SHA `aec4adc1a817c56790d1698329ef9398a15a754a` (v2026.5).

```diff
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
```

## Why

- Floating `@v2026.x` tags can silently move when retagged or force-pushed in the base-ci repo, violating supply-chain best practice.
- SHA pinning makes third-party action references byte-immutable, so even if base-ci itself is compromised CI will not pull in malicious code.
- This bumps base-ci from v2026.4 → v2026.5 and removes the last floating reference in this repo.

## Verification

- `actionlint .github/workflows/*.yml` → exit 0, no warnings.
- `rg "@v2026\." .github/` → no matches (no floating references remain).
- `rg "nocoo/base-ci" .github/` → only the new SHA-pinned line.
- `git ls-remote https://github.com/nocoo/base-ci refs/tags/v2026.5^{}` confirms `aec4adc1a817c56790d1698329ef9398a15a754a`.

Tracking issue: STU-915
