### PR TITLE
chore(deps): batch upgrade hono, lucide-react, @types/node

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "raven",
       "dependencies": {
-        "hono": "4.12.25",
+        "hono": "4.12.26",
         "micromatch": "^4.0.8",
         "next": "16.2.9",
         "vite": "8.0.16",
@@ -24,7 +24,7 @@
     },
     "packages/dashboard": {
       "name": "dashboard",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -61,7 +61,7 @@
       "name": "@raven/proxy",
       "dependencies": {
         "gpt-tokenizer": "^3.0.1",
-        "hono": "4.12.25",
+        "hono": "4.12.26",
         "socks": "^2.8.7",
         "zod": "^4.3.6",
       },
@@ -929,7 +929,7 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
-    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+    "hono": ["hono@4.12.26", "", {}, "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.20.0",
+        "lucide-react": "1.21.0",
         "next": "16.2.9",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "1.6.0",
@@ -1093,7 +1093,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.20.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ=="],
+    "lucide-react": ["lucide-react@1.21.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "25.9.3",
+        "@types/node": "26.0.0",
         "@types/react": "19.2.17",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^6.0.1",
@@ -523,7 +523,7 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
@@ -1395,7 +1395,7 @@
 
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unrs-resolver": ["unrs-resolver@1.12.1", "", { "dependencies": { "napi-postinstall": "^0.3.4" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.12.1", "@unrs/resolver-binding-android-arm64": "1.12.1", "@unrs/resolver-binding-darwin-arm64": "1.12.1", "@unrs/resolver-binding-darwin-x64": "1.12.1", "@unrs/resolver-binding-freebsd-x64": "1.12.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.12.1", "@unrs/resolver-binding-linux-arm64-musl": "1.12.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.12.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.12.1", "@unrs/resolver-binding-linux-x64-gnu": "1.12.1", "@unrs/resolver-binding-linux-x64-musl": "1.12.1", "@unrs/resolver-binding-openharmony-arm64": "1.12.1", "@unrs/resolver-binding-wasm32-wasi": "1.12.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.12.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.12.1", "@unrs/resolver-binding-win32-x64-msvc": "1.12.1" } }, "sha512-LmOTmcBbFqxu1rzubnqHT6EZeqDYpenlGYwyFhHj7oc1HdyZE+0cLQ+s9SDSK+KKQQKuoJhUbzHQ89Ubwg2Oxg=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "undici": "^7.28.0"
   },
   "dependencies": {
-    "hono": "4.12.25",
+    "hono": "4.12.26",
     "micromatch": "^4.0.8",
     "next": "16.2.9",
     "vite": "8.0.16",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,7 +31,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "25.9.3",
+    "@types/node": "26.0.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^6.0.1",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.20.0",
+    "lucide-react": "1.21.0",
     "next": "16.2.9",
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "1.6.0",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "gpt-tokenizer": "^3.0.1",
-    "hono": "4.12.25",
+    "hono": "4.12.26",
     "socks": "^2.8.7",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

3 个 dependency 升级，原子提交：

| 包 | 版本 | Scope | Commit |
|---|---|---|---|
| `hono` | 4.12.25 → 4.12.26 (patch) | root + `packages/proxy` | `5da4522` |
| `lucide-react` | 1.20.0 → 1.21.0 (minor) | `packages/dashboard` | `22d4b3d` |
| `@types/node` | 25.9.3 → 26.0.0 (MAJOR, dev) | `packages/dashboard` | `8b23a7b` |

`@types/node@26` 仅是 devDependency，跟随 Node 26 类型更新；与现有 TypeScript 6.0.3 兼容，typecheck 全绿。

## Closes

- Closes #106
- Closes #107
- Closes #110

## Test plan

- [x] `bun run typecheck` — proxy + dashboard 全绿
- [x] `bun run lint` — proxy + dashboard 全绿
- [x] `bun run test`（proxy）— Statements 97.15%, Lines 98.45%
- [x] `bun run --filter dashboard test` — Statements 90.55%
- [x] Husky pre-commit gates（lint-staged / typecheck / fetch-boundary / gitleaks）
- [x] Pre-push gates（security / coverage / arch）
- [ ] CI green on PR
