### PR TITLE
chore(deps): bump @types/node to 26.0.1 in dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "26.0.0",
+        "@types/node": "26.0.1",
         "@types/react": "19.2.17",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^6.0.3",
@@ -523,7 +523,7 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,7 +31,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "26.0.0",
+    "@types/node": "26.0.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^6.0.3",


### PR DESCRIPTION
## 📦 Summary

Patch bump `@types/node` from `26.0.0` → `26.0.1` in `packages/dashboard` (devDependencies).

Closes #123

## 🔧 Changes

- `packages/dashboard/package.json` — bump `@types/node` to `26.0.1`
- `bun.lock` — regenerated lockfile entries

## ✅ Verification

Clean reinstall (`rm -rf node_modules .next` 后 `bun add -d @types/node@26.0.1`)，本地验证全部通过：

- `bun install --frozen-lockfile` ✅
- `bun run --filter dashboard typecheck` ✅
- `bun run --filter dashboard lint` ✅
- `bun run --filter dashboard test` ✅ — 27 files / 375 tests, 90.57% statements / 95.88% lines
- `bun run --filter dashboard build` ✅
- Pre-commit gates (tests / lint-staged / typecheck / fetch-boundary / gitleaks / security / coverage / arch) ✅
- Reviewer-03 已 review 通过
