### PR TITLE
fix(proxy): refresh Copilot token + retry once on upstream token-expired 401 (MY-1028)

### DIFF
--- a/packages/proxy/src/lib/token.ts
+++ b/packages/proxy/src/lib/token.ts
@@ -164,3 +164,77 @@ async function logUser() {
   const user = await getGitHubUser()
   logger.info(`Logged in as ${user.login}`)
 }
+
+// ---------------------------------------------------------------------------
+// On-demand refresh + retry for transient Copilot upstream token-expired 401s.
+// Scheduled refresh above covers steady-state expiry; this path handles the
+// race where a request fires moments after the JWT expires but before the next
+// scheduled tick. See MY-1027 spike.
+// ---------------------------------------------------------------------------
+
+const TOKEN_EXPIRED_PATTERNS: ReadonlyArray<RegExp> = [
+  /token\s+expired/i,
+  /IDE\s+token\s+expired/i,
+]
+
+export function isTokenExpiredBody(status: number, body: string): boolean {
+  if (status !== 401) return false
+  return TOKEN_EXPIRED_PATTERNS.some((pattern) => pattern.test(body))
+}
+
+export async function refreshCopilotTokenNow(): Promise<string> {
+  const { token } = await getCopilotToken()
+  state.copilotToken = token
+  return token
+}
+
+/**
+ * Run a Copilot upstream fetch, transparently refreshing the cached JWT and
+ * retrying exactly once when the first call returns a token-expired 401.
+ *
+ * Behaviour matrix:
+ *   - 2xx                                                       → returned as-is
+ *   - non-401 non-2xx                                           → original HTTPError
+ *   - 401 + body NOT token-expired                              → original HTTPError
+ *   - 401 + body token-expired, refresh ok, retry 2xx           → retry response
+ *   - 401 + body token-expired, refresh ok, retry NOT 2xx       → retry HTTPError
+ *   - 401 + body token-expired, refresh throws                  → original HTTPError
+ */
+export async function fetchWithCopilotTokenRetry(
+  doFetch: () => Promise<Response>,
+  errorMessage: string,
+  refresh: () => Promise<unknown> = refreshCopilotTokenNow,
+): Promise<Response> {
+  const first = await doFetch()
+  if (first.ok) return first
+
+  if (first.status !== 401) {
+    throw await HTTPError.fromResponse(errorMessage, first)
+  }
+
+  const firstBody = await first.text().catch(() => "")
+  if (!isTokenExpiredBody(first.status, firstBody)) {
+    throw new HTTPError(errorMessage, first.status, firstBody)
+  }
+
+  logger.warn(
+    "Copilot upstream returned token-expired 401, refreshing and retrying once",
+    { errorMessage },
+  )
+
+  try {
+    await refresh()
+  } catch (refreshError) {
+    logger.error(
+      "Copilot token on-demand refresh failed; surfacing original 401",
+      { error: String(refreshError) },
+    )
+    throw new HTTPError(errorMessage, first.status, firstBody)
+  }
+
+  const second = await doFetch()
+  if (!second.ok) {
+    throw await HTTPError.fromResponse(errorMessage, second)
+  }
+  return second
+}

--- a/packages/proxy/src/upstream/copilot-embeddings.ts
+++ b/packages/proxy/src/upstream/copilot-embeddings.ts
@@ -3,9 +3,9 @@
  */
 
 import { copilotBaseUrl, copilotHeaders } from "../lib/api-config"
-import { HTTPError } from "../lib/error"
 import { getProxyUrl } from "../lib/socks5-bridge"
 import { state } from "../lib/state"
+import { fetchWithCopilotTokenRetry } from "../lib/token"
 import type { UpstreamClient, UpstreamResult } from "./interface"
 
 export interface EmbeddingRequest {
@@ -44,17 +44,20 @@ export class CopilotEmbeddingsClient
   async send(payload: EmbeddingRequest): Promise<UpstreamResult<EmbeddingResponse>> {
     this.config.getToken()
 
+    const body = JSON.stringify(payload)
     const proxyUrl = this.config.getProxyUrl()
-    const response = await fetch(`${this.config.getBaseUrl()}/embeddings`, {
-      method: "POST",
-      headers: this.config.getHeaders(),
-      body: JSON.stringify(payload),
-      ...(proxyUrl ? { proxy: proxyUrl } : {}),
-    } as RequestInit)
+    const url = `${this.config.getBaseUrl()}/embeddings`
 
-    if (!response.ok) {
-      throw await HTTPError.fromResponse("Failed to create embeddings", response)
-    }
+    const response = await fetchWithCopilotTokenRetry(
+      () =>
+        fetch(url, {
+          method: "POST",
+          headers: this.config.getHeaders(),
+          body,
+          ...(proxyUrl ? { proxy: proxyUrl } : {}),
+        } as RequestInit),
+      "Failed to create embeddings",
+    )
 
     return (await response.json()) as EmbeddingResponse
   }

--- a/packages/proxy/src/upstream/copilot-native.ts
+++ b/packages/proxy/src/upstream/copilot-native.ts
@@ -6,9 +6,9 @@
 
 import { events, type ServerSentEvent } from "../util/sse"
 import { copilotBaseUrl, copilotHeaders } from "../lib/api-config"
-import { HTTPError } from "../lib/error"
 import { getProxyUrl } from "../lib/socks5-bridge"
 import { state } from "../lib/state"
+import { fetchWithCopilotTokenRetry } from "../lib/token"
 import { getModelCapabilities } from "../strategies/support/model-capabilities"
 import type {
   AnthropicMessagesPayload,
@@ -48,22 +48,11 @@ export class CopilotNativeClient
 
     const normalizedPayload = normalizeNativeThinkingPayload(req.payload, req.options.copilotModel)
 
-    const headers: Record<string, string> = {
-      ...this.config.getHeaders(),
-      "anthropic-version": "2023-06-01",
-    }
-
     const anthropicBeta = buildNativeAnthropicBeta(normalizedPayload, req.options.anthropicBeta ?? null)
-    if (anthropicBeta) headers["anthropic-beta"] = anthropicBeta
-
-    if (checkForVision(normalizedPayload)) {
-      headers["copilot-vision-request"] = "true"
-    }
-
+    const visionRequest = checkForVision(normalizedPayload)
     const isAgentCall = normalizedPayload.messages.some(
       (msg) => msg.role === "assistant" || hasToolResultContent(msg),
     )
-    headers["X-Initiator"] = isAgentCall ? "agent" : "user"
 
     const requestBody: Record<string, unknown> = {
       ...sanitizeNativeMessagesPayload(normalizedPayload),
@@ -78,17 +67,29 @@ export class CopilotNativeClient
       delete requestBody.output_config
     }
 
+    const body = JSON.stringify(requestBody)
     const proxyUrl = this.config.getProxyUrl()
-    const response = await fetch(`${this.config.getBaseUrl()}/v1/messages`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(requestBody),
-      ...(proxyUrl ? { proxy: proxyUrl } : {}),
-    } as RequestInit)
+    const url = `${this.config.getBaseUrl()}/v1/messages`
 
-    if (!response.ok) {
-      throw await HTTPError.fromResponse("Failed to create native messages", response)
-    }
+    const response = await fetchWithCopilotTokenRetry(
+      () => {
+        // Re-read headers each attempt so refreshed Authorization flows through.
+        const headers: Record<string, string> = {
+          ...this.config.getHeaders(),
+          "anthropic-version": "2023-06-01",
+        }
+        if (anthropicBeta) headers["anthropic-beta"] = anthropicBeta
+        if (visionRequest) headers["copilot-vision-request"] = "true"
+        headers["X-Initiator"] = isAgentCall ? "agent" : "user"
+        return fetch(url, {
+          method: "POST",
+          headers,
+          body,
+          ...(proxyUrl ? { proxy: proxyUrl } : {}),
+        } as RequestInit)
+      },
+      "Failed to create native messages",
+    )
 
     if (normalizedPayload.stream) {
       return events(response) as AsyncGenerator<ServerSentEvent>

--- a/packages/proxy/src/upstream/copilot-openai.ts
+++ b/packages/proxy/src/upstream/copilot-openai.ts
@@ -8,9 +8,9 @@
 
 import { events, type ServerSentEvent } from "../util/sse"
 import { copilotBaseUrl, copilotHeaders } from "../lib/api-config"
-import { HTTPError } from "../lib/error"
 import { getProxyUrl } from "../lib/socks5-bridge"
 import { state } from "../lib/state"
+import { fetchWithCopilotTokenRetry } from "../lib/token"
 import type { UpstreamClient, UpstreamResult } from "./interface"
 
 // ---------------------------------------------------------------------------
@@ -198,22 +198,26 @@ export class CopilotOpenAIClient
       ["assistant", "tool"].includes(msg.role),
     )
 
-    const headers: Record<string, string> = {
-      ...this.config.getHeaders(enableVision),
-      "X-Initiator": isAgentCall ? "agent" : "user",
-    }
-
+    const body = JSON.stringify(payload)
     const proxyUrl = this.config.getProxyUrl()
-    const response = await fetch(`${this.config.getBaseUrl()}/chat/completions`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(payload),
-      ...(proxyUrl ? { proxy: proxyUrl } : {}),
-    } as RequestInit)
+    const url = `${this.config.getBaseUrl()}/chat/completions`
 
-    if (!response.ok) {
-      throw await HTTPError.fromResponse("Failed to create chat completions", response)
-    }
+    const response = await fetchWithCopilotTokenRetry(
+      () => {
+        // Re-read headers each attempt so refreshed Authorization flows through.
+        const headers: Record<string, string> = {
+          ...this.config.getHeaders(enableVision),
+          "X-Initiator": isAgentCall ? "agent" : "user",
+        }
+        return fetch(url, {
+          method: "POST",
+          headers,
+          body,
+          ...(proxyUrl ? { proxy: proxyUrl } : {}),
+        } as RequestInit)
+      },
+      "Failed to create chat completions",
+    )
 
     if (payload.stream) {
       return events(response) as AsyncGenerator<ServerSentEvent>

--- a/packages/proxy/src/upstream/copilot-responses.ts
+++ b/packages/proxy/src/upstream/copilot-responses.ts
@@ -7,9 +7,9 @@
 
 import { events, type ServerSentEvent } from "../util/sse"
 import { copilotBaseUrl, copilotHeaders } from "../lib/api-config"
-import { HTTPError } from "../lib/error"
 import { getProxyUrl } from "../lib/socks5-bridge"
 import { state } from "../lib/state"
+import { fetchWithCopilotTokenRetry } from "../lib/token"
 import type { UpstreamClient, UpstreamResult } from "./interface"
 
 export interface ResponsesPayload {
@@ -37,22 +37,25 @@ export class CopilotResponsesClient
     const enableVision = hasVisionContent(payload)
     const isAgentCall = hasAgentHistory(payload)
 
-    const headers: Record<string, string> = {
-      ...this.config.getHeaders(enableVision),
-      "X-Initiator": isAgentCall ? "agent" : "user",
-    }
-
+    const body = JSON.stringify(payload)
     const proxyUrl = this.config.getProxyUrl()
-    const response = await fetch(`${this.config.getBaseUrl()}/responses`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(payload),
-      ...(proxyUrl ? { proxy: proxyUrl } : {}),
-    } as RequestInit)
+    const url = `${this.config.getBaseUrl()}/responses`
 
-    if (!response.ok) {
-      throw await HTTPError.fromResponse("Failed to create responses", response)
-    }
+    const response = await fetchWithCopilotTokenRetry(
+      () => {
+        const headers: Record<string, string> = {
+          ...this.config.getHeaders(enableVision),
+          "X-Initiator": isAgentCall ? "agent" : "user",
+        }
+        return fetch(url, {
+          method: "POST",
+          headers,
+          body,
+          ...(proxyUrl ? { proxy: proxyUrl } : {}),
+        } as RequestInit)
+      },
+      "Failed to create responses",
+    )
 
     if (payload.stream) {
       return events(response) as AsyncGenerator<ServerSentEvent>

--- a/packages/proxy/test/lib/token.test.ts
+++ b/packages/proxy/test/lib/token.test.ts
@@ -40,7 +40,7 @@ vi.mock("../../src/lib/utils", () => ({
 }))
 
 // Import AFTER mock is registered
-const { setupGitHubToken, setupCopilotToken } = await import("../../src/lib/token")
+const { setupGitHubToken, setupCopilotToken, fetchWithCopilotTokenRetry, isTokenExpiredBody } = await import("../../src/lib/token")
 
 // ---------------------------------------------------------------------------
 // State save/restore + fetch spy
@@ -379,5 +379,142 @@ describe("setupCopilotToken", () => {
 
     expect(fakeTimers.timers[3]!.type).toBe("timeout")
     expect(fakeTimers.timers[3]!.ms).toBe(20_000)
+  })
+})
+
+// ===========================================================================
+// fetchWithCopilotTokenRetry + isTokenExpiredBody
+// ===========================================================================
+
+describe("isTokenExpiredBody", () => {
+  test("returns false for non-401 status", () => {
+    expect(isTokenExpiredBody(500, "token expired")).toBe(false)
+    expect(isTokenExpiredBody(200, "token expired")).toBe(false)
+  })
+
+  test("matches `token expired` (case-insensitive, with spacing variants)", () => {
+    expect(isTokenExpiredBody(401, "token expired")).toBe(true)
+    expect(isTokenExpiredBody(401, "Token Expired")).toBe(true)
+    expect(isTokenExpiredBody(401, '{"error":{"message":"the token has expired, see ..."}}')).toBe(false)
+    expect(isTokenExpiredBody(401, "internal: token  expired again")).toBe(true)
+  })
+
+  test("matches `IDE token expired`", () => {
+    expect(isTokenExpiredBody(401, '{"message":"IDE token expired"}')).toBe(true)
+    expect(isTokenExpiredBody(401, "ide token expired (please refresh)")).toBe(true)
+  })
+
+  test("does NOT match unrelated 401 bodies", () => {
+    expect(isTokenExpiredBody(401, "unauthorized")).toBe(false)
+    expect(isTokenExpiredBody(401, '{"error":"forbidden"}')).toBe(false)
+    expect(isTokenExpiredBody(401, "")).toBe(false)
+  })
+})
+
+describe("fetchWithCopilotTokenRetry", () => {
+  type FetchFn = () => Promise<Response>
+
+  test("2xx on first call returns response without invoking refresh", async () => {
+    const refresh = vi.fn().mockResolvedValue("new")
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(new Response("{}", { status: 200 })))
+    const res = await fetchWithCopilotTokenRetry(doFetch, "boom", refresh)
+    expect(res.status).toBe(200)
+    expect(refresh).not.toHaveBeenCalled()
+    expect(doFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("non-401 error throws HTTPError without invoking refresh", async () => {
+    const refresh = vi.fn()
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(new Response("server error", { status: 500 })))
+    await expect(fetchWithCopilotTokenRetry(doFetch, "boom", refresh)).rejects.toMatchObject({
+      message: "boom",
+      status: 500,
+      responseBody: "server error",
+    })
+    expect(refresh).not.toHaveBeenCalled()
+    expect(doFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("401 with non-token-expired body throws original HTTPError, no refresh", async () => {
+    const refresh = vi.fn()
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(new Response("unauthorized: bad scope", { status: 401 })))
+    await expect(fetchWithCopilotTokenRetry(doFetch, "boom", refresh)).rejects.toMatchObject({
+      message: "boom",
+      status: 401,
+      responseBody: "unauthorized: bad scope",
+    })
+    expect(refresh).not.toHaveBeenCalled()
+    expect(doFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("401 token-expired, refresh succeeds, retry succeeds → returns retry response", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const responses: Response[] = [
+      new Response("token expired", { status: 401 }),
+      new Response('{"ok":true}', { status: 200 }),
+    ]
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(responses.shift()!))
+    const res = await fetchWithCopilotTokenRetry(doFetch, "boom", refresh)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('{"ok":true}')
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(doFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test("401 token-expired with IDE phrasing also triggers retry", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const responses: Response[] = [
+      new Response('{"error":{"message":"IDE token expired"}}', { status: 401 }),
+      new Response("{}", { status: 200 }),
+    ]
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(responses.shift()!))
+    const res = await fetchWithCopilotTokenRetry(doFetch, "boom", refresh)
+    expect(res.status).toBe(200)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(doFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test("401 token-expired, refresh throws → surfaces original 401, no retry", async () => {
+    const refresh = vi.fn().mockRejectedValue(new Error("refresh upstream 500"))
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(new Response("token expired", { status: 401 })))
+    await expect(fetchWithCopilotTokenRetry(doFetch, "boom", refresh)).rejects.toMatchObject({
+      message: "boom",
+      status: 401,
+      responseBody: "token expired",
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(doFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("401 token-expired, refresh succeeds, retry still 401 → HTTPError from retry, no third call", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const responses: Response[] = [
+      new Response("token expired", { status: 401 }),
+      new Response("still token expired", { status: 401 }),
+    ]
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(responses.shift()!))
+    await expect(fetchWithCopilotTokenRetry(doFetch, "boom", refresh)).rejects.toMatchObject({
+      message: "boom",
+      status: 401,
+      responseBody: "still token expired",
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(doFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test("retry must surface the *retry* error body (does not double-up on token refresh)", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const responses: Response[] = [
+      new Response("token expired", { status: 401 }),
+      new Response("post-refresh 500", { status: 500 }),
+    ]
+    const doFetch: FetchFn = vi.fn(() => Promise.resolve(responses.shift()!))
+    await expect(fetchWithCopilotTokenRetry(doFetch, "boom", refresh)).rejects.toMatchObject({
+      message: "boom",
+      status: 500,
+      responseBody: "post-refresh 500",
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(doFetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/proxy/test/upstream/copilot-embeddings.test.ts
+++ b/packages/proxy/test/upstream/copilot-embeddings.test.ts
@@ -144,4 +144,48 @@ describe("CopilotEmbeddingsClient (E.6)", () => {
     expect(captured[0]!.proxy).toBe("http://127.0.0.1:9999")
     expect(captured[0]!.headers["x-injected"]).toBe("yes")
   })
+
+  test("MY-1028: refreshes Copilot token and retries once on token-expired 401", async () => {
+    spy.mockRestore()
+    state.copilotToken = "stale-jwt"
+    state.vsCodeVersion = "1.90.0"
+    state.accountType = "individual"
+    state.copilotChatVersion = "0.45.1"
+
+    const calls: Array<{ url: string; authHeader: string | null }> = []
+    spy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString()
+      const headers = normaliseHeaders(init?.headers)
+      calls.push({ url, authHeader: headers.authorization ?? null })
+
+      if (url.includes("/copilot_internal/v2/token")) {
+        return new Response(
+          JSON.stringify({ token: "fresh-jwt", expires_at: 9_999_999_999, refresh_in: 1500 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.endsWith("/embeddings")) {
+        if (calls.filter((c) => c.url.endsWith("/embeddings")).length === 1) {
+          return new Response("token expired", { status: 401 })
+        }
+        return new Response(
+          JSON.stringify({ object: "list", data: [], model: "m", usage: { prompt_tokens: 0, total_tokens: 0 } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      return new Response("unexpected", { status: 500 })
+    }) as unknown as typeof fetch)
+
+    const client = createDefaultCopilotEmbeddingsClient()
+    const result = (await client.send({ input: "hello", model: "m" })) as { object: string }
+    expect(result.object).toBe("list")
+    const embCalls = calls.filter((c) => c.url.endsWith("/embeddings"))
+    expect(embCalls).toHaveLength(2)
+    expect(embCalls[0]!.authHeader).toBe("Bearer stale-jwt")
+    expect(embCalls[1]!.authHeader).toBe("Bearer fresh-jwt")
+    expect(state.copilotToken).toBe("fresh-jwt")
+  })
 })

--- a/packages/proxy/test/upstream/copilot-native.test.ts
+++ b/packages/proxy/test/upstream/copilot-native.test.ts
@@ -290,4 +290,80 @@ describe("CopilotNativeClient (E.4)", () => {
     expect(tool.name).toBe("lookup")
     expect(tool.input_schema).toEqual({ type: "object" })
   })
+
+  test("MY-1028: refreshes Copilot token and retries once on token-expired 401", async () => {
+    spy.mockRestore()
+    state.copilotToken = "stale-jwt"
+    state.vsCodeVersion = "1.90.0"
+    state.accountType = "individual"
+    state.copilotChatVersion = "0.45.1"
+
+    const calls: Array<{ url: string; authHeader: string | null }> = []
+    spy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString()
+      const headers = normaliseHeaders(init?.headers)
+      calls.push({ url, authHeader: headers.authorization ?? null })
+
+      if (url.includes("/copilot_internal/v2/token")) {
+        return new Response(
+          JSON.stringify({ token: "fresh-jwt", expires_at: 9_999_999_999, refresh_in: 1500 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.endsWith("/v1/messages")) {
+        if (calls.filter((c) => c.url.endsWith("/v1/messages")).length === 1) {
+          return new Response('{"error":{"message":"IDE token expired"}}', { status: 401 })
+        }
+        return new Response("{}", { status: 200, headers: { "content-type": "application/json" } })
+      }
+      return new Response("unexpected", { status: 500 })
+    }) as unknown as typeof fetch)
+
+    const client = createDefaultCopilotNativeClient()
+    const result = await client.send({
+      payload: makePayload(),
+      options: { copilotModel: "claude-x" },
+    })
+    expect(result).toEqual({})
+
+    const msgCalls = calls.filter((c) => c.url.endsWith("/v1/messages"))
+    expect(msgCalls).toHaveLength(2)
+    expect(msgCalls[0]!.authHeader).toBe("Bearer stale-jwt")
+    expect(msgCalls[1]!.authHeader).toBe("Bearer fresh-jwt")
+    expect(state.copilotToken).toBe("fresh-jwt")
+  })
+
+  test("MY-1028: refresh failure surfaces original 401, no retry", async () => {
+    spy.mockRestore()
+    state.copilotToken = "stale-jwt"
+    state.vsCodeVersion = "1.90.0"
+    state.accountType = "individual"
+    state.copilotChatVersion = "0.45.1"
+
+    let msgCalls = 0
+    spy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.includes("/copilot_internal/v2/token")) {
+        return new Response("upstream 500", { status: 500 })
+      }
+      if (url.endsWith("/v1/messages")) {
+        msgCalls++
+        return new Response("token expired", { status: 401 })
+      }
+      return new Response("unexpected", { status: 500 })
+    }) as unknown as typeof fetch)
+
+    const client = createDefaultCopilotNativeClient()
+    await expect(
+      client.send({ payload: makePayload(), options: { copilotModel: "claude-x" } }),
+    ).rejects.toThrow("Failed to create native messages")
+    expect(msgCalls).toBe(1)
+    // Refresh failed, so cached token is untouched.
+    expect(state.copilotToken).toBe("stale-jwt")
+  })
 })

--- a/packages/proxy/test/upstream/copilot-openai.test.ts
+++ b/packages/proxy/test/upstream/copilot-openai.test.ts
@@ -189,4 +189,71 @@ describe("CopilotOpenAIClient (E.3)", () => {
     expect(captured[0]!.headers["x-injected"]).toBe("yes")
     expect(captured[0]!.headers["x-initiator"]).toBe("user")
   })
+
+  test("MY-1028: refreshes Copilot token and retries once on token-expired 401", async () => {
+    spy.mockRestore()
+    state.copilotToken = "stale-jwt"
+    state.vsCodeVersion = "1.90.0"
+    state.accountType = "individual"
+    state.copilotChatVersion = "0.45.1"
+
+    const calls: Array<{ url: string; authHeader: string | null }> = []
+    spy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString()
+      const headers = normaliseHeaders(init?.headers)
+      calls.push({ url, authHeader: headers.authorization ?? null })
+
+      if (url.includes("/copilot_internal/v2/token")) {
+        return new Response(
+          JSON.stringify({ token: "fresh-jwt", expires_at: 9_999_999_999, refresh_in: 1500 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.includes("/chat/completions")) {
+        if (calls.filter((c) => c.url.includes("/chat/completions")).length === 1) {
+          return new Response("token expired", { status: 401 })
+        }
+        return new Response("{}", { status: 200, headers: { "content-type": "application/json" } })
+      }
+      return new Response("unexpected", { status: 500 })
+    }) as unknown as typeof fetch)
+
+    const client = createDefaultCopilotOpenAIClient()
+    const result = await client.send({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "x" }],
+    })
+    expect(result).toEqual({})
+
+    const chatCalls = calls.filter((c) => c.url.includes("/chat/completions"))
+    expect(chatCalls).toHaveLength(2)
+    expect(chatCalls[0]!.authHeader).toBe("Bearer stale-jwt")
+    // Retry must carry the refreshed JWT.
+    expect(chatCalls[1]!.authHeader).toBe("Bearer fresh-jwt")
+    expect(state.copilotToken).toBe("fresh-jwt")
+  })
+
+  test("MY-1028: 401 without token-expired marker is NOT retried", async () => {
+    spy.mockRestore()
+    state.copilotToken = "stale-jwt"
+    state.vsCodeVersion = "1.90.0"
+    state.accountType = "individual"
+    state.copilotChatVersion = "0.45.1"
+
+    let calls = 0
+    spy = vi.spyOn(globalThis, "fetch").mockImplementation((() => {
+      calls++
+      return Promise.resolve(new Response("unauthorized: bad scope", { status: 401 }))
+    }) as unknown as typeof fetch)
+
+    const client = createDefaultCopilotOpenAIClient()
+    await expect(
+      client.send({ model: "gpt-4o", messages: [{ role: "user", content: "x" }] }),
+    ).rejects.toThrow("Failed to create chat completions")
+    expect(calls).toBe(1)
+    expect(state.copilotToken).toBe("stale-jwt")
+  })
 })

--- a/packages/proxy/test/upstream/copilot-responses.test.ts
+++ b/packages/proxy/test/upstream/copilot-responses.test.ts
@@ -176,4 +176,77 @@ describe("CopilotResponsesClient (E.5)", () => {
     })
     expect(captured[0]!.headers["copilot-vision-request"]).toBe("true")
   })
+
+  test("MY-1028: refreshes Copilot token and retries once on token-expired 401", async () => {
+    spy.mockRestore()
+    state.copilotToken = "stale-jwt"
+    state.vsCodeVersion = "1.90.0"
+    state.accountType = "individual"
+    state.copilotChatVersion = "0.45.1"
+
+    const calls: Array<{ url: string; authHeader: string | null }> = []
+    spy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString()
+      const headers = normaliseHeaders(init?.headers)
+      calls.push({ url, authHeader: headers.authorization ?? null })
+
+      if (url.includes("/copilot_internal/v2/token")) {
+        return new Response(
+          JSON.stringify({ token: "fresh-jwt", expires_at: 9_999_999_999, refresh_in: 1500 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.endsWith("/responses")) {
+        if (calls.filter((c) => c.url.endsWith("/responses")).length === 1) {
+          return new Response("token expired", { status: 401 })
+        }
+        return new Response("{}", { status: 200, headers: { "content-type": "application/json" } })
+      }
+      return new Response("unexpected", { status: 500 })
+    }) as unknown as typeof fetch)
+
+    const client = createDefaultCopilotResponsesClient()
+    const result = await client.send({ model: "gpt-5", input: [] })
+    expect(result).toEqual({})
+    const respCalls = calls.filter((c) => c.url.endsWith("/responses"))
+    expect(respCalls).toHaveLength(2)
+    expect(respCalls[0]!.authHeader).toBe("Bearer stale-jwt")
+    expect(respCalls[1]!.authHeader).toBe("Bearer fresh-jwt")
+    expect(state.copilotToken).toBe("fresh-jwt")
+  })
+
+  test("MY-1028: retry-still-401 surfaces retry HTTPError", async () => {
+    spy.mockRestore()
+    state.copilotToken = "stale-jwt"
+    state.vsCodeVersion = "1.90.0"
+    state.accountType = "individual"
+    state.copilotChatVersion = "0.45.1"
+
+    let respCalls = 0
+    spy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.includes("/copilot_internal/v2/token")) {
+        return new Response(
+          JSON.stringify({ token: "fresh-jwt", expires_at: 9_999_999_999, refresh_in: 1500 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.endsWith("/responses")) {
+        respCalls++
+        // Both attempts return token-expired so the contract retries exactly once
+        // and surfaces the retry HTTPError without looping.
+        return new Response("token expired", { status: 401 })
+      }
+      return new Response("unexpected", { status: 500 })
+    }) as unknown as typeof fetch)
+
+    const client = createDefaultCopilotResponsesClient()
+    await expect(client.send({ model: "gpt-5", input: [] })).rejects.toThrow("Failed to create responses")
+    expect(respCalls).toBe(2)
+  })
 })


### PR DESCRIPTION
## Scope (MY-1028, follow-up to MY-1027 spike)

Smallest durable Raven proxy fix for transient Copilot upstream token-expired 401s.

The scheduled `scheduleTokenRefresh` (in `packages/proxy/src/lib/token.ts`) covers steady-state JWT expiry, but Copilot upstream clients still propagated transient `token expired` / `IDE token expired` 401s when a request fired in the brief window after JWT expiry but before the next scheduled tick. Agents saw bare 401s on what is recoverable upstream state.

## Change

Adds a shared on-demand refresh + single retry path, used by all four Copilot upstream clients.

`fetchWithCopilotTokenRetry(doFetch, errorMessage)` in `packages/proxy/src/lib/token.ts`:

| First response | Action |
| --- | --- |
| 2xx | returned as-is |
| non-401 | original `HTTPError` |
| 401, body does NOT match `token expired` / `IDE token expired` | original `HTTPError` (no refresh, no retry) |
| 401, body matches | call `refreshCopilotTokenNow()` (which calls `getCopilotToken()` and updates `state.copilotToken`) and retry exactly once |
| ↳ refresh throws | original 401 surfaced |
| ↳ retry 2xx | returned |
| ↳ retry non-2xx | retry `HTTPError` (no third call, no loop) |

`copilot-openai`, `copilot-native`, `copilot-responses`, and `copilot-embeddings` each wrap their `fetch` in this helper. Headers are re-read inside the closure so the refreshed `Authorization: Bearer <fresh-jwt>` flows through on the retry.

## Files changed (in scope per issue)

- `packages/proxy/src/lib/token.ts` — added helper + refresh function
- `packages/proxy/src/upstream/copilot-openai.ts`
- `packages/proxy/src/upstream/copilot-native.ts`
- `packages/proxy/src/upstream/copilot-responses.ts`
- `packages/proxy/src/upstream/copilot-embeddings.ts`
- `packages/proxy/test/lib/token.test.ts` — direct helper tests (8 cases incl. status guard, IDE phrasing, refresh failure, retry-still-401, retry HTTPError body)
- `packages/proxy/test/upstream/copilot-openai.test.ts` — retry success + non-token-expired no-retry
- `packages/proxy/test/upstream/copilot-native.test.ts` — retry success + refresh-failure-no-retry
- `packages/proxy/test/upstream/copilot-responses.test.ts` — retry success + retry-still-401
- `packages/proxy/test/upstream/copilot-embeddings.test.ts` — retry success

## Verification

| Command | Result |
| --- | --- |
| `bun run --filter '@raven/proxy' test` | **1744 passed (113 files)** |
| `bun run --filter '@raven/proxy' typecheck` | **exit 0** |
| `bun run --filter '@raven/proxy' lint` | **exit 0** |
| `bun run gate:arch` (depcruise + fetch-boundary) | **no violations** |
| pre-commit hooks (tests, lint-staged, typecheck, fetch-boundary, gitleaks) | **all green** |
| pre-push hooks (security, coverage, arch) | **all green** |

`git diff --name-status origin/main...HEAD` only touches the 10 in-scope files listed above. No app/UI/CLI files were changed.

## Notes

- The refresh function delegates to the existing `getCopilotToken()` service, so SOCKS proxy routing, headers, and error semantics for the refresh call itself are unchanged.
- The scheduled refresh loop (`scheduleTokenRefresh` / `retryTokenRefresh`) is untouched — this PR only adds an in-flight safety net.
- No "infinite retry" risk: a token-expired 401 produces at most one extra upstream call per request.