### PR TITLE
chore(deps): upgrade lucide-react 1.21.0 → 1.22.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.21.0",
+        "lucide-react": "1.22.0",
         "next": "16.2.9",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "1.6.0",
@@ -1093,7 +1093,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.21.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ=="],
+    "lucide-react": ["lucide-react@1.22.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.21.0",
+    "lucide-react": "1.22.0",
     "next": "16.2.9",
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "1.6.0",


### PR DESCRIPTION
## Summary

Bumps `lucide-react` in `packages/dashboard` from `1.21.0` to `1.22.0`.

Resolves the lucide-react line item from #130.

## Changes

- `packages/dashboard/package.json`: `lucide-react` `1.21.0` → `1.22.0`
- `bun.lock`: only the two corresponding `lucide-react` entries updated, no transitive churn

## Verification

- `bun install` — lockfile updated, 3 packages resolved/extracted
- `bun run typecheck` (workspace) — pass
- `bun run lint` (workspace, `--max-warnings=0`) — pass
- `bun run test:all` — dashboard 375/375, @raven/proxy 1725/1725
- `bun scripts/gate-security.ts` — osv-scanner clean, gitleaks clean
- Pre-commit + pre-push hooks — all gates green

Same-group review approved by Reviewer-04 on STU-1420.
