### PR TITLE
test(proxy): restore L1 coverage gate

### DIFF
--- a/packages/proxy/test/lib/utils.test.ts
+++ b/packages/proxy/test/lib/utils.test.ts
@@ -9,6 +9,8 @@ import {
   cacheOptimizations,
   cacheProviders,
   cacheIPWhitelist,
+  cacheCorsSettings,
+  cacheSocks5Settings,
   isNullish,
   sleep,
 } from "../../src/lib/utils"
@@ -575,5 +577,101 @@ describe("cacheProviders with invalid model_patterns", () => {
     expect(state.providers).toHaveLength(1)
 
     loggerSpy.mockRestore()
+  })
+})
+
+// ===========================================================================
+// cacheCorsSettings
+// ===========================================================================
+
+describe("cacheCorsSettings", () => {
+  test("enabled flag + parsed array of allowed origins", () => {
+    db.query("INSERT INTO settings (key, value) VALUES ($k, $v)").run({
+      $k: "cors_enabled",
+      $v: "true",
+    })
+    db.query("INSERT INTO settings (key, value) VALUES ($k, $v)").run({
+      $k: "cors_allowed_origins",
+      $v: JSON.stringify(["https://example.com", "https://app.example.com"]),
+    })
+
+    cacheCorsSettings(db)
+
+    expect(state.corsEnabled).toBe(true)
+    expect(state.corsAllowedOrigins).toEqual([
+      "https://example.com",
+      "https://app.example.com",
+    ])
+  })
+
+  test("non-array JSON resets allowed origins to []", () => {
+    db.query("INSERT INTO settings (key, value) VALUES ($k, $v)").run({
+      $k: "cors_allowed_origins",
+      $v: JSON.stringify({ not: "an array" }),
+    })
+
+    cacheCorsSettings(db)
+    expect(state.corsAllowedOrigins).toEqual([])
+  })
+
+  test("invalid JSON catch keeps allowed origins as []", () => {
+    db.query("INSERT INTO settings (key, value) VALUES ($k, $v)").run({
+      $k: "cors_allowed_origins",
+      $v: "not-valid-json{{{",
+    })
+
+    cacheCorsSettings(db)
+    expect(state.corsAllowedOrigins).toEqual([])
+  })
+
+  test("missing setting resets allowed origins to []", () => {
+    cacheCorsSettings(db)
+    expect(state.corsEnabled).toBe(false)
+    expect(state.corsAllowedOrigins).toEqual([])
+  })
+})
+
+// ===========================================================================
+// cacheSocks5Settings
+// ===========================================================================
+
+describe("cacheSocks5Settings", () => {
+  test("reads host/port/username/password + copilot policy from DB", () => {
+    const rows: Array<[string, string]> = [
+      ["socks5_enabled", "true"],
+      ["socks5_host", "127.0.0.1"],
+      ["socks5_port", "1080"],
+      ["socks5_username", "u"],
+      ["socks5_password", "p"],
+      ["socks5_copilot", "on"],
+    ]
+    for (const [k, v] of rows) {
+      db.query("INSERT INTO settings (key, value) VALUES ($k, $v)").run({ $k: k, $v: v })
+    }
+
+    cacheSocks5Settings(db)
+    expect(state.socks5Enabled).toBe(true)
+    expect(state.socks5Host).toBe("127.0.0.1")
+    expect(state.socks5Port).toBe(1080)
+    expect(state.socks5Username).toBe("u")
+    expect(state.socks5Password).toBe("p")
+    expect(state.socks5CopilotPolicy).toBe("on")
+  })
+
+  test("unknown copilot policy falls back to 'default'", () => {
+    db.query("INSERT INTO settings (key, value) VALUES ($k, $v)").run({
+      $k: "socks5_copilot",
+      $v: "weird",
+    })
+    cacheSocks5Settings(db)
+    expect(state.socks5CopilotPolicy).toBe("default")
+  })
+
+  test("missing settings → null host / null port / 'default' copilot policy", () => {
+    cacheSocks5Settings(db)
+    expect(state.socks5Enabled).toBe(false)
+    expect(state.socks5Host).toBeNull()
+    expect(state.socks5Port).toBeNull()
+    expect(state.socks5CopilotPolicy).toBe("default")
   })
 })

--- a/packages/proxy/test/upstream/copilot-native-thinking.test.ts
+++ b/packages/proxy/test/upstream/copilot-native-thinking.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Coverage backfill for copilot-native pure helpers reached only via
+ * `normalizeNativeThinkingPayload()` — the adaptive_thinking → effort-pick
+ * → sanitizeOutputConfig chain (lib lines 209-230 + 301-348). These are
+ * exercised end-to-end via send() with state.models populated.
+ *
+ * The existing `legacy/create-native-messages.test.ts` declares the same
+ * model with `adaptive_thinking: false`, so the adaptive branch is unhit
+ * in the baseline coverage. We flip it on here and walk the request body
+ * to assert the normalization landed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { state } from "../../src/lib/state"
+import {
+  CopilotNativeClient,
+  defaultCopilotNativeConfig,
+  type CopilotNativeRequest,
+} from "../../src/upstream/copilot-native"
+import type { AnthropicMessagesPayload } from "../../src/protocols/anthropic/types"
+import type { ModelsResponse } from "../../src/services/copilot/get-models"
+
+interface CapturedRequest {
+  url: string
+  body: { thinking?: { type: string }; output_config?: { effort?: string } | null }
+}
+
+function makePayload(overrides: Partial<AnthropicMessagesPayload> = {}): AnthropicMessagesPayload {
+  return {
+    model: "claude-opus-4-6",
+    messages: [{ role: "user", content: "hi" }],
+    max_tokens: 4096,
+    ...overrides,
+  } as AnthropicMessagesPayload
+}
+
+function captureFetch(): { spy: ReturnType<typeof vi.spyOn>; captured: CapturedRequest[] } {
+  const captured: CapturedRequest[] = []
+  const spy = vi.spyOn(globalThis, "fetch").mockImplementation(((
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : input.toString()
+    const bodyText = typeof init?.body === "string" ? init.body : ""
+    captured.push({ url, body: bodyText ? JSON.parse(bodyText) : {} })
+    return Promise.resolve(
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    )
+  }) as unknown as typeof fetch)
+  return { spy, captured }
+}
+
+function modelsWith(opts: {
+  reasoning_effort?: string[]
+  adaptive_thinking?: boolean
+}): ModelsResponse {
+  return {
+    object: "list",
+    data: [
+      {
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        object: "model",
+        version: "2025-08-20",
+        vendor: "anthropic",
+        preview: false,
+        model_picker_enabled: true,
+        capabilities: {
+          family: "claude",
+          tokenizer: "cl100k_base",
+          object: "model_capabilities",
+          type: "chat",
+          supports: {
+            tool_calls: true,
+            parallel_tool_calls: true,
+            dimensions: null,
+            adaptive_thinking: opts.adaptive_thinking ?? true,
+            ...(opts.reasoning_effort ? { reasoning_effort: opts.reasoning_effort } : {}),
+          },
+          limits: {
+            max_context_window_tokens: 200000,
+            max_output_tokens: 8192,
+            max_prompt_tokens: null,
+            max_inputs: null,
+          },
+        },
+        policy: null,
+        supported_endpoints: ["/v1/messages"],
+      },
+    ],
+  }
+}
+
+const SAVED = {
+  copilotToken: state.copilotToken,
+  vsCodeVersion: state.vsCodeVersion,
+  accountType: state.accountType,
+  copilotChatVersion: state.copilotChatVersion,
+  models: state.models,
+}
+
+let spy: ReturnType<typeof vi.spyOn>
+let captured: CapturedRequest[]
+
+beforeEach(() => {
+  state.copilotToken = "tok"
+  state.vsCodeVersion = "1.90.0"
+  state.accountType = "individual"
+  state.copilotChatVersion = "0.45.1"
+  ;({ spy, captured } = captureFetch())
+})
+
+afterEach(() => {
+  spy.mockRestore()
+  state.copilotToken = SAVED.copilotToken
+  state.vsCodeVersion = SAVED.vsCodeVersion
+  state.accountType = SAVED.accountType
+  state.copilotChatVersion = SAVED.copilotChatVersion
+  state.models = SAVED.models
+})
+
+async function send(payload: AnthropicMessagesPayload, copilotModel = "claude-opus-4-6") {
+  const client = new CopilotNativeClient(defaultCopilotNativeConfig())
+  await client.send({
+    payload,
+    options: { copilotModel },
+  } as CopilotNativeRequest)
+}
+
+describe("copilot-native normalizeNativeThinkingPayload", () => {
+  test("non-thinking payload passes through unchanged", async () => {
+    state.models = modelsWith({})
+    await send(makePayload())
+    expect(captured[0]!.body.thinking).toBeUndefined()
+    expect(captured[0]!.body.output_config).toBeUndefined()
+  })
+
+  test("thinking + adaptive_thinking=false: payload unchanged", async () => {
+    state.models = modelsWith({ adaptive_thinking: false })
+    await send(
+      makePayload({ thinking: { type: "enabled", budget_tokens: 1024 } } as Partial<
+        AnthropicMessagesPayload
+      >),
+    )
+    expect(captured[0]!.body.thinking).toEqual({ type: "enabled", budget_tokens: 1024 })
+  })
+
+  test("thinking + adaptive + no model capabilities found: passes through", async () => {
+    state.models = { object: "list", data: [] }
+    await send(
+      makePayload({ thinking: { type: "enabled", budget_tokens: 1024 } } as Partial<
+        AnthropicMessagesPayload
+      >),
+    )
+    expect(captured[0]!.body.thinking).toEqual({ type: "enabled", budget_tokens: 1024 })
+  })
+
+  test("budget 0/null → effort 'high'; rewrites to adaptive", async () => {
+    state.models = modelsWith({})
+    await send(
+      makePayload({ thinking: { type: "enabled", budget_tokens: 0 } } as Partial<
+        AnthropicMessagesPayload
+      >),
+    )
+    expect(captured[0]!.body.thinking).toEqual({ type: "adaptive" })
+    expect(captured[0]!.body.output_config).toEqual({ effort: "high" })
+  })
+
+  test("budget ≤2048 → effort 'low'", async () => {
+    state.models = modelsWith({})
+    await send(
+      makePayload({ thinking: { type: "enabled", budget_tokens: 1024 } } as Partial<
+        AnthropicMessagesPayload
+      >),
+    )
+    expect(captured[0]!.body.output_config).toEqual({ effort: "low" })
+  })
+
+  test("budget ≤8192 → effort 'medium'", async () => {
+    state.models = modelsWith({})
+    await send(
+      makePayload({ thinking: { type: "enabled", budget_tokens: 4096 } } as Partial<
+        AnthropicMessagesPayload
+      >),
+    )
+    expect(captured[0]!.body.output_config).toEqual({ effort: "medium" })
+  })
+
+  test("budget >8192 → effort 'high'", async () => {
+    state.models = modelsWith({})
+    await send(
+      makePayload({ thinking: { type: "enabled", budget_tokens: 16000 } } as Partial<
+        AnthropicMessagesPayload
+      >),
+    )
+    expect(captured[0]!.body.output_config).toEqual({ effort: "high" })
+  })
+
+  test("requested effort included in supported list passes through", async () => {
+    state.models = modelsWith({ reasoning_effort: ["low", "medium", "high"] })
+    await send(
+      makePayload({
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: { effort: "medium" },
+      } as Partial<AnthropicMessagesPayload>),
+    )
+    expect(captured[0]!.body.output_config).toEqual({ effort: "medium" })
+  })
+
+  test("requested effort missing → picks closest supported (lower)", async () => {
+    state.models = modelsWith({ reasoning_effort: ["low", "high"] })
+    await send(
+      makePayload({
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: { effort: "medium" },
+      } as Partial<AnthropicMessagesPayload>),
+    )
+    // EFFORT_PRIORITY = ["max","xhigh","high","medium","low"]
+    // medium idx=3; supported indices: high=2 (|3-2|=1), low=4 (|3-4|=1).
+    // Tie-break prefers the higher PRIORITY index → "low".
+    expect(captured[0]!.body.output_config).toEqual({ effort: "low" })
+  })
+
+  test("supported list empty filtered → returns requested", async () => {
+    state.models = modelsWith({ reasoning_effort: ["unknown-effort"] })
+    await send(
+      makePayload({
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: { effort: "medium" },
+      } as Partial<AnthropicMessagesPayload>),
+    )
+    expect(captured[0]!.body.output_config).toEqual({ effort: "medium" })
+  })
+
+  test("output_config without effort sanitizes to null", async () => {
+    state.models = modelsWith({})
+    await send(
+      makePayload({
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: {} as Exclude<AnthropicMessagesPayload["output_config"], undefined>,
+      } as Partial<AnthropicMessagesPayload>),
+    )
+    // sanitizeOutputConfig({}) → null; supportedEffort=medium → output_config: { effort: "medium" }
+    expect(captured[0]!.body.output_config).toEqual({ effort: "medium" })
+  })
+})

--- a/packages/proxy/test/upstream/default-config-accessors.test.ts
+++ b/packages/proxy/test/upstream/default-config-accessors.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Coverage backfill for the `defaultCopilotXxxConfig()` factory accessors
+ * across the four Copilot upstream clients. The fixture-driven tests in
+ * `copilot-openai.test.ts` / `copilot-native.test.ts` / etc. only exercise
+ * `getToken()` + `snapshotAuth()`, leaving `getBaseUrl()` / `getHeaders()` /
+ * `getProxyUrl()` and the `snapshotAuth` token-missing path uncovered.
+ *
+ * Those accessors are the public seam strategies use to derive request-side
+ * inputs; regressions there silently break the live path even when send()
+ * tests still match fixtures, so we cover them directly.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { state } from "../../src/lib/state"
+import { defaultCopilotEmbeddingsConfig } from "../../src/upstream/copilot-embeddings"
+import { defaultCopilotNativeConfig } from "../../src/upstream/copilot-native"
+import { defaultCopilotOpenAIConfig } from "../../src/upstream/copilot-openai"
+import { defaultCopilotResponsesConfig } from "../../src/upstream/copilot-responses"
+
+const SAVED = {
+  copilotToken: state.copilotToken,
+  vsCodeVersion: state.vsCodeVersion,
+  accountType: state.accountType,
+  copilotChatVersion: state.copilotChatVersion,
+}
+
+beforeEach(() => {
+  state.copilotToken = "tok-default"
+  state.vsCodeVersion = "1.90.0"
+  state.accountType = "individual"
+  state.copilotChatVersion = "0.45.1"
+})
+
+afterEach(() => {
+  state.copilotToken = SAVED.copilotToken
+  state.vsCodeVersion = SAVED.vsCodeVersion
+  state.accountType = SAVED.accountType
+  state.copilotChatVersion = SAVED.copilotChatVersion
+})
+
+describe("defaultCopilotEmbeddingsConfig accessors", () => {
+  test("getToken/getBaseUrl/getHeaders/getProxyUrl read from state", () => {
+    const cfg = defaultCopilotEmbeddingsConfig()
+    expect(cfg.getToken()).toBe("tok-default")
+    expect(typeof cfg.getBaseUrl()).toBe("string")
+    expect(cfg.getBaseUrl().length).toBeGreaterThan(0)
+    expect(typeof cfg.getHeaders()).toBe("object")
+    expect(cfg.getProxyUrl()).toBeUndefined()
+  })
+
+  test("getToken throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotEmbeddingsConfig()
+    expect(() => cfg.getToken()).toThrow("Copilot token not found")
+  })
+
+  test("snapshotAuth throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotEmbeddingsConfig()
+    expect(() => cfg.snapshotAuth()).toThrow("Copilot token not found")
+  })
+
+  test("snapshotAuth returns Bearer header for current state token", () => {
+    const { token, headers } = defaultCopilotEmbeddingsConfig().snapshotAuth()
+    expect(token).toBe("tok-default")
+    expect(headers.Authorization).toBe("Bearer tok-default")
+  })
+})
+
+describe("defaultCopilotNativeConfig accessors", () => {
+  test("getToken/getBaseUrl/getHeaders/getProxyUrl read from state", () => {
+    const cfg = defaultCopilotNativeConfig()
+    expect(cfg.getToken()).toBe("tok-default")
+    expect(typeof cfg.getBaseUrl()).toBe("string")
+    expect(cfg.getBaseUrl().length).toBeGreaterThan(0)
+    expect(typeof cfg.getHeaders()).toBe("object")
+    expect(cfg.getProxyUrl()).toBeUndefined()
+  })
+
+  test("getToken throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotNativeConfig()
+    expect(() => cfg.getToken()).toThrow("Copilot token not found")
+  })
+
+  test("snapshotAuth throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotNativeConfig()
+    expect(() =>
+      cfg.snapshotAuth({ anthropicBeta: null, visionRequest: false, isAgentCall: false }),
+    ).toThrow("Copilot token not found")
+  })
+
+  test("snapshotAuth stamps anthropic-version + X-Initiator and optional beta", () => {
+    const cfg = defaultCopilotNativeConfig()
+    const userCall = cfg.snapshotAuth({
+      anthropicBeta: null,
+      visionRequest: false,
+      isAgentCall: false,
+    })
+    expect(userCall.token).toBe("tok-default")
+    expect(userCall.headers["anthropic-version"]).toBe("2023-06-01")
+    expect(userCall.headers["X-Initiator"]).toBe("user")
+    expect(userCall.headers["anthropic-beta"]).toBeUndefined()
+
+    const agentBeta = cfg.snapshotAuth({
+      anthropicBeta: "interleaved-thinking-2025-05-14",
+      visionRequest: true,
+      isAgentCall: true,
+    })
+    expect(agentBeta.headers["X-Initiator"]).toBe("agent")
+    expect(agentBeta.headers["anthropic-beta"]).toBe("interleaved-thinking-2025-05-14")
+  })
+})
+
+describe("defaultCopilotOpenAIConfig accessors", () => {
+  test("getToken/getBaseUrl/getHeaders/getProxyUrl read from state", () => {
+    const cfg = defaultCopilotOpenAIConfig()
+    expect(cfg.getToken()).toBe("tok-default")
+    expect(typeof cfg.getBaseUrl()).toBe("string")
+    expect(cfg.getBaseUrl().length).toBeGreaterThan(0)
+    expect(typeof cfg.getHeaders(false)).toBe("object")
+    expect(cfg.getProxyUrl()).toBeUndefined()
+  })
+
+  test("getToken throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotOpenAIConfig()
+    expect(() => cfg.getToken()).toThrow("Copilot token not found")
+  })
+
+  test("snapshotAuth throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotOpenAIConfig()
+    expect(() => cfg.snapshotAuth({ enableVision: false, isAgentCall: false })).toThrow(
+      "Copilot token not found",
+    )
+  })
+
+  test("snapshotAuth stamps X-Initiator user/agent based on isAgentCall", () => {
+    const cfg = defaultCopilotOpenAIConfig()
+    expect(cfg.snapshotAuth({ enableVision: false, isAgentCall: false }).headers["X-Initiator"]).toBe(
+      "user",
+    )
+    expect(cfg.snapshotAuth({ enableVision: true, isAgentCall: true }).headers["X-Initiator"]).toBe(
+      "agent",
+    )
+  })
+})
+
+describe("defaultCopilotResponsesConfig accessors", () => {
+  test("getToken/getBaseUrl/getHeaders/getProxyUrl read from state", () => {
+    const cfg = defaultCopilotResponsesConfig()
+    expect(cfg.getToken()).toBe("tok-default")
+    expect(typeof cfg.getBaseUrl()).toBe("string")
+    expect(cfg.getBaseUrl().length).toBeGreaterThan(0)
+    expect(typeof cfg.getHeaders(false)).toBe("object")
+    expect(cfg.getProxyUrl()).toBeUndefined()
+  })
+
+  test("getToken throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotResponsesConfig()
+    expect(() => cfg.getToken()).toThrow("Copilot token not found")
+  })
+
+  test("snapshotAuth throws when state token missing", () => {
+    state.copilotToken = null
+    const cfg = defaultCopilotResponsesConfig()
+    expect(() => cfg.snapshotAuth({ enableVision: false, isAgentCall: false })).toThrow(
+      "Copilot token not found",
+    )
+  })
+
+  test("snapshotAuth stamps X-Initiator user/agent based on isAgentCall", () => {
+    const cfg = defaultCopilotResponsesConfig()
+    expect(cfg.snapshotAuth({ enableVision: false, isAgentCall: false }).headers["X-Initiator"]).toBe(
+      "user",
+    )
+    expect(cfg.snapshotAuth({ enableVision: true, isAgentCall: true }).headers["X-Initiator"]).toBe(
+      "agent",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Adds coverage for Copilot upstream default config accessors and token-missing branches.
- Adds native thinking normalization coverage through send() paths.
- Adds cache CORS/SOCKS5 utility coverage, including parse-failure handling.

## Verification

- SDE-02 reported 1844 / 1844 tests green.
- Reviewer-02 reproduced targeted vitest, proxy test, coverage gate, typecheck, and lint.
- Coverage gate: 98.56% global, upstream/ 99.66%, lib/ 97.49%.

STU-1462
