### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
Adds root `.npmrc` supply-chain security baseline.

Tracking Multica issue: STU-1519 (`cc0efd33-4019-4a19-8383-534b9fad0d10`)

Content pinned verbatim from the issue template:
- `registry` pinned to official npm
- `save-exact=true` + `package-lock=true` for lockfile integrity
- `engine-strict=true` for Node/npm consistency
- `audit=true` + `audit-level=high` gating
- `fund=false` noise reduction

Scope: `.npmrc` only; no `package.json` / `bun.lock` / `bunfig.toml` / CI / hooks touched. `bun install` intentionally not run — this file does not affect existing deps.
