### PR TITLE
chore(deps): upgrade recharts 3.9.1 → 3.9.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "radix-ui": "1.6.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "recharts": "3.9.1",
+        "recharts": "3.9.2",
         "swr": "2.4.2",
         "tailwind-merge": "^3.3.0",
         "tw-animate-css": "^1.3.4",
@@ -1219,7 +1219,7 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "recharts": ["recharts@3.9.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg=="],
+    "recharts": ["recharts@3.9.2", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw=="],
 
     "rechoir": ["rechoir@0.8.0", "", { "dependencies": { "resolve": "^1.20.0" } }, "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -20,7 +20,7 @@
     "radix-ui": "1.6.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "recharts": "3.9.1",
+    "recharts": "3.9.2",
     "swr": "2.4.2",
     "tailwind-merge": "^3.3.0",
     "tw-animate-css": "^1.3.4"


### PR DESCRIPTION
## Summary
- Patch bump `recharts` 3.9.1 → 3.9.2 in `packages/dashboard`
- Lockfile refreshed via `bun install`

## Verification
- `bun run test:all`: proxy 1844/1844 + dashboard 411/411 pass
- `bun run gate:security`: osv-scanner + gitleaks clean
- pre-commit hook (L1 tests / lint-staged / typecheck / fetch-boundary / gitleaks) 全部通过

Closes #149