### PR TITLE
chore(deps): upgrade @types/node 26.1.0 → 26.1.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "26.1.0",
+        "@types/node": "26.1.1",
         "@types/react": "19.2.17",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^6.0.3",
@@ -523,7 +523,7 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,7 +31,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "26.1.0",
+    "@types/node": "26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^6.0.3",


### PR DESCRIPTION
## Summary

- Bump `@types/node` in `packages/dashboard` from `26.1.0` to `26.1.1` (patch).

## Lockfile

`bun.lock` diff is limited to the workspace declaration and the top-level `@types/node` entry; transitive `undici-types: ~8.3.0` unchanged, no other packages drifted.

## Verification (local)

macOS arm64, bun 1.3.14, node 26.4.0.

- `bun install --frozen-lockfile` — clean, no drift
- `bun run build` — dashboard production build exits 0
- `bun run typecheck` — proxy + dashboard exit 0
- `bun run lint` — 0 warning
- `bun run test:all` — dashboard 411/411, proxy 1844/1844
- `bun run gate:arch` — 106 modules / 409 deps cruised, fetch-boundary clean
- `bun run gate:security` — osv-scanner 0 vuln, gitleaks clean
- Pre-commit + pre-push hooks — all green

L2 (`test:e2e`) and L3 (`test:ui`) remain manual-only per anti-ban / manual-only rules; this bump is a devDep type-declaration patch and does not touch runtime code.

## Related

The sibling issue #159 (`typescript 6.0.3 → 7.0.2`) was investigated and deferred — TypeScript 7 is the new Native Port (Go), which no longer exposes the CJS `typescript` programmatic API that Next.js 16.2.10's build-time TS integration requires. Local `bun run build` reproduces a Next TS auto-install fallback that ends in a build-worker crash. That bump is not included in this PR; a blocked note has been added on #159 and it stays open pending upstream Next.js compatibility.

Closes #158
