### PR TITLE
chore(deps): bump lucide-react 1.24.0 → 1.25.0 in dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.24.0",
+        "lucide-react": "1.25.0",
         "next": "16.2.10",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "1.6.2",
@@ -861,7 +861,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.24.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA=="],
+    "lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.24.0",
+    "lucide-react": "1.25.0",
     "next": "16.2.10",
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "1.6.2",


### PR DESCRIPTION
Bumps `lucide-react` from `1.24.0` → `1.25.0` in `packages/dashboard` (minor).

## Verification
- ✅ `bun run typecheck` — proxy + dashboard 均通过
- ✅ `bun run lint` — 0 warnings / 0 errors
- ✅ `bun run test:all` — proxy 1844/1844, dashboard 426/426 全绿
- ✅ Pre-commit hook (L1 + G1 + G2) 全绿

Related: STU-1970
Closes #177
