### PR TITLE
chore(deps): bump next-auth 5.0.0-beta.31 → 5.0.0-beta.32 (STU-2176)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "1.25.0",
         "next": "16.2.11",
-        "next-auth": "^5.0.0-beta.30",
+        "next-auth": "^5.0.0-beta.32",
         "radix-ui": "1.6.5",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -95,7 +95,7 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
-    "@auth/core": ["@auth/core@0.41.2", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^6.0.6", "oauth4webapi": "^3.3.0", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^7.0.7" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w=="],
+    "@auth/core": ["@auth/core@0.41.3", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^6.0.6", "oauth4webapi": "^3.3.0", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^7.0.7 || ^8.0.5" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -873,7 +873,7 @@
 
     "next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
-    "next-auth": ["next-auth@5.0.0-beta.31", "", { "dependencies": { "@auth/core": "0.41.2" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0", "nodemailer": "^7.0.7", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q=="],
+    "next-auth": ["next-auth@5.0.0-beta.32", "", { "dependencies": { "@auth/core": "0.41.3" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0", "nodemailer": "^7.0.7 || ^8.0.5", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q=="],
 
     "node-releases": ["node-releases@2.0.44", "", {}, "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -16,7 +16,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "1.25.0",
     "next": "16.2.11",
-    "next-auth": "^5.0.0-beta.30",
+    "next-auth": "^5.0.0-beta.32",
     "radix-ui": "1.6.5",
     "react": "19.2.8",
     "react-dom": "19.2.8",


### PR DESCRIPTION
## Summary

Bump `next-auth` from `5.0.0-beta.31` to `5.0.0-beta.32` in `packages/dashboard`. This transitively upgrades `@auth/core` from `0.41.2` to `0.41.3` (both packages share the same 2026-07 security release train).

Multica: STU-2176.

## Security fixes covered

- `GHSA-7rqj-j65f-68wh` (critical) — Auth.js email normalizer validates the address before Unicode normalization, allowing a homoglyph `@` bypass.
- `GHSA-8fpg-xm3f-6cx3` (critical, `next-auth` only) — Configuration errors can cause existence-based auth checks to fail open (auth object populated on error).
- `GHSA-x445-f3h2-j279` (moderate) — OAuth `state` / nonce / PKCE check cookies are not bound to the provider that created them.
- `GHSA-xmf8-cvqr-rfgj` (high) — `getToken()` throws an uncaught exception on malformed `Bearer` authorization headers.

Closes #199.
Closes #200.

## Diff scope

Two files, two-line direct change:

- `packages/dashboard/package.json`: `"next-auth": "^5.0.0-beta.30"` → `"^5.0.0-beta.32"`.
- `bun.lock`: `next-auth 5.0.0-beta.31 → 5.0.0-beta.32`, `@auth/core 0.41.2 → 0.41.3`. No unrelated packages moved, no registry-mirror URLs leaked into the lockfile.

## Verification

- `bun install --frozen-lockfile` — clean install, working tree stays clean, resolves `next-auth@5.0.0-beta.32` + `@auth/core@0.41.3` (verified independently by reviewer).
- `bun run test:all` — proxy 118 files + dashboard 31 files pass (2270 tests total).
- `bun run typecheck` — 0 errors.
- `bun run lint` — 0 errors, 0 warnings.
- pre-commit (L1 + G1 + G2) and pre-push (G1 arch/lint + L1 coverage + G2 security) hooks all green.
