### PR TITLE
chore(security): drop stale undici override, narrow ip-address to caret (STU-2490)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -77,10 +77,9 @@
     "@babel/core": ">=7.29.6",
     "brace-expansion": ">=5.0.5",
     "flatted": ">=3.4.2",
-    "ip-address": ">=10.3.1",
+    "ip-address": "^10.3.1",
     "postcss": ">=8.5.18",
     "sharp": ">=0.35.0",
-    "undici": "^7.29.0",
     "vite": "8.1.5",
   },
   "packages": {
@@ -1018,7 +1017,7 @@
 
     "typescript6-for-depcruise": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "vite": "8.1.5",
     "postcss": ">=8.5.18",
     "@babel/core": ">=7.29.6",
-    "undici": "^7.29.0",
-    "ip-address": ">=10.3.1",
+    "ip-address": "^10.3.1",
     "sharp": ">=0.35.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

STU-2490 后续整改：只保留两处对 `main` 的定向调整，命中 Reviewer-01 上一轮阻断项。

- 移除过期的 `overrides.undici: "^7.29.0"`。`jsdom@30.0.1` 声明 `undici: ^8.9.0`，v7.x override 是跨主版本槽位违规。移除后 `bun why undici` 显示 `jsdom@30.0.1 → undici@8.10.0`，5 条相关 GHSA（GHSA-4cwx / 8xcm / jr45 / m8rv / v3r7）在 8.10.0 均已修复，G2 覆盖不变。
- 收窄 `overrides.ip-address` 从 `>=10.3.1` 到 `^10.3.1`。实际锁定仍为 `10.4.0`（满足 `socks@2.8.9` 的 `^10.1.1`），加上主版本上界防止未来重算跨到 11.x。

单一原子提交，仅动 2 文件：`package.json`、`bun.lock`，共 +3/−5。没有 Hono 或其他依赖差异。未使用 `--no-verify`，未改 OSV ignore。

## Validation

- `bun install --frozen-lockfile --ignore-scripts` ✅（no changes）
- `bun run gate:security` ✅（osv-scanner + gitleaks 全绿）
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test:all` ✅（proxy 125 files / 1932 tests、dashboard 31 files / 426 tests）
- `bun run build` ✅
- Pre-commit + pre-push hook 全绿

## Review

Reviewer-01 已确认代码侧闭环，本 PR 保持等待流程指示后再合并。

Closes STU-2490
