### PR TITLE
chore(deps): bump lucide-react 1.27.0 → 1.28.0 in dashboard (STU-2426)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.27.0",
+        "lucide-react": "1.28.0",
         "next": "16.2.12",
         "next-auth": "^5.0.0-beta.32",
         "radix-ui": "1.6.7",
@@ -845,7 +845,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@1.27.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw=="],
+    "lucide-react": ["lucide-react@1.28.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.27.0",
+    "lucide-react": "1.28.0",
     "next": "16.2.12",
     "next-auth": "^5.0.0-beta.32",
     "radix-ui": "1.6.7",


### PR DESCRIPTION
## Summary

Bump `lucide-react` from `1.27.0` to `1.28.0` in `packages/dashboard`.

- `packages/dashboard/package.json`: version pin
- `bun.lock`: matching resolution (no mirror pollution)

Refs: STU-2426
Closes #220

## Verification

`packages/dashboard`:

- `bun run --filter dashboard typecheck` — pass
- `bun run --filter dashboard lint` (biome, 157 files) — pass
- `bun run --filter dashboard test` (vitest + coverage) — **426 passed / 31 files**; Statements 91.7%, Lines 96.37%
- `bun run --filter dashboard build` — pass

## Notes

- Pre-push `gate:security` (osv-scanner) reports 9 pre-existing CVEs (undici / hono / ip-address) that also fail on a clean `origin/main`. They are unrelated to this bump and out of scope; push authorized via one-off `--no-verify` per squad decision.
