### PR TITLE
STU-2866: upgrade lucide-react to 1.29.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.28.0",
+        "lucide-react": "1.29.0",
         "next": "16.3.0",
         "next-auth": "^5.0.0-beta.32",
         "radix-ui": "1.6.7",
@@ -833,7 +833,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@1.28.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg=="],
+    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.28.0",
+    "lucide-react": "1.29.0",
     "next": "16.3.0",
     "next-auth": "^5.0.0-beta.32",
     "radix-ui": "1.6.7",


### PR DESCRIPTION
## Summary

- upgrade dashboard `lucide-react` from 1.28.0 to 1.29.0
- refresh the Bun lockfile resolution and integrity

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run test:all` (2,380 tests passed)
- `bun run test:root` (2,421 tests passed)
- `bun run test:l2` (453 tests passed)
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run gate:arch`
- `bun run gate:coverage`
- `bun run gate:security`
- pre-commit and pre-push gates

L3 Playwright baseline failures were reproduced on both 1.28.0 and 1.29.0 and are unrelated to this dependency update.

Closes #235
Closes STU-2866
