### PR TITLE
STU-3032: upgrade hono to 4.13.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "raven",
       "dependencies": {
-        "hono": "4.13.0",
+        "hono": "4.13.1",
         "micromatch": "^4.0.8",
         "next": "16.3.0",
         "vite": "8.2.1",
@@ -62,7 +62,7 @@
       "name": "@raven/proxy",
       "dependencies": {
         "gpt-tokenizer": "^3.0.1",
-        "hono": "4.13.0",
+        "hono": "4.13.1",
         "socks": "^2.8.7",
         "zod": "^4.3.6",
       },
@@ -753,7 +753,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "sharp": ">=0.35.0"
   },
   "dependencies": {
-    "hono": "4.13.0",
+    "hono": "4.13.1",
     "micromatch": "^4.0.8",
     "next": "16.3.0",
     "vite": "8.2.1",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "gpt-tokenizer": "^3.0.1",
-    "hono": "4.13.0",
+    "hono": "4.13.1",
     "socks": "^2.8.7",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

- upgrade `hono` from 4.13.0 to 4.13.1 in the root workspace and `packages/proxy`
- refresh the Bun lockfile for the new package version and integrity

## Validation

- `bun run test:all` — 157 files, 2380 tests passed
- `bun run test:l2` — 27 files, 453 tests passed
- `bun run lint`
- `bun run typecheck`
- `bun run gate:arch`
- `bun run gate:coverage`
- `bun run gate:security`
- `bun run build`
- `bun install --frozen-lockfile --ignore-scripts`

Closes STU-3032
Closes #240
