### PR TITLE
STU-3033: upgrade @types/node to 26.2.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
         "@testing-library/jest-dom": "7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.3",
-        "@types/node": "26.1.2",
+        "@types/node": "26.2.0",
         "@types/react": "19.2.18",
         "@types/react-dom": "^19.2.4",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
@@ -527,7 +527,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -32,7 +32,7 @@
     "@testing-library/jest-dom": "7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.3",
-    "@types/node": "26.1.2",
+    "@types/node": "26.2.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "^19.2.4",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",


### PR DESCRIPTION
## Summary

- upgrade dashboard `@types/node` from `26.1.2` to `26.2.0`
- refresh the Bun lockfile entry and integrity hash

## Validation

- `bun install --frozen-lockfile`
- dashboard typecheck
- dashboard lint (158 files)
- dashboard tests (32 files, 436 tests)
- pre-commit and pre-push gates

Closes STU-3033
Closes #239
