### PR TITLE
STU-3031: upgrade lucide-react to 1.30.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.29.0",
+        "lucide-react": "1.30.0",
         "next": "16.3.0",
         "next-auth": "^5.0.0-beta.32",
         "radix-ui": "1.6.7",
@@ -833,7 +833,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
+    "lucide-react": ["lucide-react@1.30.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.29.0",
+    "lucide-react": "1.30.0",
     "next": "16.3.0",
     "next-auth": "^5.0.0-beta.32",
     "radix-ui": "1.6.7",


### PR DESCRIPTION
## Summary

- upgrade dashboard `lucide-react` from 1.29.0 to 1.30.0
- refresh the Bun lockfile resolution and integrity

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter dashboard lint`
- `bun run --filter dashboard typecheck`
- `bun run --filter dashboard test` — 32 files, 436 tests passed
- `bun run --filter dashboard build`
- pre-commit and pre-push gates

Closes STU-3031
Closes #241
