### PR TITLE
STU-3433: upgrade swr 2.5.0 → 2.5.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "recharts": "3.10.1",
-        "swr": "2.5.0",
+        "swr": "2.5.1",
         "tailwind-merge": "^3.3.0",
         "tw-animate-css": "^1.3.4",
       },
@@ -965,7 +965,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "swr": ["swr@2.5.0", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA=="],
+    "swr": ["swr@2.5.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "recharts": "3.10.1",
-    "swr": "2.5.0",
+    "swr": "2.5.1",
     "tailwind-merge": "^3.3.0",
     "tw-animate-css": "^1.3.4"
   },


### PR DESCRIPTION
## Summary

- Upgrade dashboard dependency `swr` from `2.5.0` to `2.5.1` (patch)
- Lockfile updated via official registry; no business logic changes

## Test plan

- [x] `bun run test:all` — proxy 1944 / dashboard 436 passed
- [x] Pre-commit gates (typecheck, lint, coverage, gitleaks)
- [x] Reviewer-01 independent recheck (dashboard tests, typecheck, lint, Next.js production build)

Closes STU-3433
Closes #257