### PR TITLE
STU-3570: pin nanoid 3.3.18 override (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,7 @@
     "brace-expansion": ">=5.0.5",
     "flatted": ">=3.4.2",
     "ip-address": "^10.3.1",
+    "nanoid": "3.3.18",
     "postcss": ">=8.5.25",
     "sharp": ">=0.35.0",
     "vite": "8.2.1",
@@ -853,7 +854,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "next": ["next@16.3.0", "", { "dependencies": { "@next/env": "16.3.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0", "@next/swc-darwin-x64": "16.3.0", "@next/swc-linux-arm64-gnu": "16.3.0", "@next/swc-linux-arm64-musl": "16.3.0", "@next/swc-linux-x64-gnu": "16.3.0", "@next/swc-linux-x64-musl": "16.3.0", "@next/swc-win32-arm64-msvc": "16.3.0", "@next/swc-win32-x64-msvc": "16.3.0", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "postcss": ">=8.5.25",
     "@babel/core": ">=7.29.6",
     "ip-address": "^10.3.1",
-    "sharp": ">=0.35.0"
+    "sharp": ">=0.35.0",
+    "nanoid": "3.3.18"
   },
   "dependencies": {
     "hono": "4.13.1",


### PR DESCRIPTION
## Summary
- Pin transitive `nanoid` to `3.3.18` via root `overrides` to fix [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (infinite loop when size is zero).
- Brought in only through `postcss@8.5.26` (next / vite / @tailwindcss/postcss). Exact pin avoids Bun resolving `>=3.3.18` to major 6.x.
- No business logic changes.

Closes #260

## Test plan
- [x] `bun why nanoid` → unique `nanoid@3.3.18`
- [x] `bun install --frozen-lockfile`
- [x] `bun run typecheck`
- [x] `bun run test:all` (proxy 1944 + dashboard 436)
- [x] `bun run test:root` (2421)
- [x] `bun run gate:security` (osv-scanner + gitleaks clean)
- [x] pre-commit + pre-push gates green