### PR TITLE
STU-3569: upgrade hono 4.13.1 → 4.13.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "raven",
       "dependencies": {
-        "hono": "4.13.1",
+        "hono": "4.13.2",
         "micromatch": "^4.0.8",
         "next": "16.3.0",
         "vite": "8.2.1",
@@ -62,7 +62,7 @@
       "name": "@raven/proxy",
       "dependencies": {
         "gpt-tokenizer": "^3.0.1",
-        "hono": "4.13.1",
+        "hono": "4.13.2",
         "socks": "^2.8.7",
         "zod": "^4.3.6",
       },
@@ -754,7 +754,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
+    "hono": ["hono@4.13.2", "", {}, "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "nanoid": "3.3.18"
   },
   "dependencies": {
-    "hono": "4.13.1",
+    "hono": "4.13.2",
     "micromatch": "^4.0.8",
     "next": "16.3.0",
     "vite": "8.2.1",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "gpt-tokenizer": "^3.0.1",
-    "hono": "4.13.1",
+    "hono": "4.13.2",
     "socks": "^2.8.7",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

- Bump `hono` from 4.13.1 to 4.13.2 in root and `@raven/proxy` manifests, with matching `bun.lock` update.
- Patch-only upstream release; no business logic changes.
- Relevant note: CORS middleware perf pre-joins static header options; dynamic origin callback semantics unchanged.

## Test plan

- [x] `bun run test:all` — proxy 125 files / 1944 tests; dashboard 32 files / 436 tests
- [x] `@raven/proxy` typecheck
- [x] pre-commit gates (L1/G1/G2)
- [x] Reviewer independent verification (frozen install, full test, typecheck, lint)
- [x] Rebased onto `main` after nanoid pin (#262) so G2 security gate passes

Closes STU-3569
Closes #259