### PR TITLE
STU-3662: bump gpt-tokenizer 3.0.1 → 4.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,7 +61,7 @@
     "packages/proxy": {
       "name": "@raven/proxy",
       "dependencies": {
-        "gpt-tokenizer": "^3.0.1",
+        "gpt-tokenizer": "4.0.0",
         "hono": "4.13.2",
         "socks": "^2.8.7",
         "zod": "^4.3.6",
@@ -746,7 +746,7 @@
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
-    "gpt-tokenizer": ["gpt-tokenizer@3.4.0", "", {}, "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ=="],
+    "gpt-tokenizer": ["gpt-tokenizer@4.0.0", "", {}, "sha512-YAWIyzvuVUHEfW7tFfFAxH8qQb+Q3RU9nYOTy7skMNX5qzU6Q8jxTHZLyO56ug1vYvCR7wndzpd3jwD86/mhjQ=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -14,7 +14,7 @@
     "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "gpt-tokenizer": "^3.0.1",
+    "gpt-tokenizer": "4.0.0",
     "hono": "4.13.2",
     "socks": "^2.8.7",
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary
- Bump `gpt-tokenizer` from `^3.0.1` to `4.0.0` in `@raven/proxy`
- Closes GitHub #265 / Multica STU-3662

## Breaking change review
v4.0.0 BREAKING CHANGES (upstream release notes):
- UMD bundles and the unpkg global entry point are removed

Not applicable here: we only use ESM dynamic imports of
`gpt-tokenizer/encoding/*` and `encode()` in `packages/proxy/src/lib/tokenizer.ts`.
All five encodings still export `encode`. No source changes required.

## Test plan
- [x] Reviewer-01 approved local commit (content of `745c238`, rebased to `94ed5a4` on latest main)
- [x] `bun run test:all` — proxy 1944 + dashboard 436 tests
- [x] `tokenizer.test.ts` 22/22
- [x] pre-commit / pre-push gates green
- [ ] CI green

Closes #265