### PR TITLE
STU-3881: bump hono 4.13.2 → 4.13.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "raven",
       "dependencies": {
-        "hono": "4.13.2",
+        "hono": "4.13.3",
         "micromatch": "^4.0.8",
         "next": "16.3.1",
         "vite": "8.2.1",
@@ -62,7 +62,7 @@
       "name": "@raven/proxy",
       "dependencies": {
         "gpt-tokenizer": "4.0.0",
-        "hono": "4.13.2",
+        "hono": "4.13.3",
         "socks": "^2.8.7",
         "zod": "^4.3.6",
       },
@@ -754,7 +754,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.13.2", "", {}, "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA=="],
+    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "nanoid": "3.3.18"
   },
   "dependencies": {
-    "hono": "4.13.2",
+    "hono": "4.13.3",
     "micromatch": "^4.0.8",
     "next": "16.3.1",
     "vite": "8.2.1",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "gpt-tokenizer": "4.0.0",
-    "hono": "4.13.2",
+    "hono": "4.13.3",
     "socks": "^2.8.7",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary
- Bump `hono` 4.13.2 → 4.13.3 (root + `@raven/proxy`)
- Lockfile updated; no source or config changes

## Test plan
- [x] `bun install --frozen-lockfile` (Reviewer verified)
- [x] `bun run test` — 125 files / 1944 tests passed
- [x] `bun run --filter '@raven/proxy' typecheck`
- [x] pre-commit / pre-push gates (L1/G1/G2)

Closes STU-3881
Closes #273