### PR TITLE
STU-3993: bump lucide-react 1.32.0 → 1.33.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.32.0",
+        "lucide-react": "1.33.0",
         "next": "16.3.1",
         "next-auth": "^5.0.0-beta.32",
         "radix-ui": "1.6.7",
@@ -834,7 +834,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@1.32.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-txX56hMFnRxPi1f9/nH69YN8uvAO6a7Y1KSWKjCDAtdD9+soEgmWuCt6iRm1pkxUZo2+YntSdsE1L6bIuKoY8Q=="],
+    "lucide-react": ["lucide-react@1.33.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.32.0",
+    "lucide-react": "1.33.0",
     "next": "16.3.1",
     "next-auth": "^5.0.0-beta.32",
     "radix-ui": "1.6.7",


### PR DESCRIPTION
## Summary
- Bump `lucide-react` from `1.32.0` to `1.33.0` in the dashboard package.
- Lockfile updated via `bun install`; no application code changes.

Closes STU-3993
Fixes nocoo/raven#283

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run --filter dashboard typecheck`
- [x] `bun run --filter dashboard lint`
- [x] `bun run --filter dashboard test` (32 files / 436 tests)
- [x] Pre-commit + pre-push gates green
- [x] Independent Reviewer re-verification (typecheck/lint/tests/production build)