### PR TITLE
[deps] @types/node 26.2.0 → 26.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "14.6.6",
-        "@types/node": "26.2.0",
+        "@types/node": "26.3.0",
         "@types/react": "19.2.18",
         "@types/react-dom": "^19.2.5",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
@@ -530,7 +530,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -32,7 +32,7 @@
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "14.6.6",
-    "@types/node": "26.2.0",
+    "@types/node": "26.3.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "^19.2.5",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",


### PR DESCRIPTION
## Summary

升级 `@types/node` 从 26.2.0 到 26.3.0，完成 [nocoo/raven#300](https://github.com/nocoo/raven/issues/300) 任务。

Closes STU-4337

## Changes

- `packages/dashboard/package.json`: `@types/node` 26.2.0 → 26.3.0
- `bun.lock`: 更新依赖锁

## Verification

- ✅ typecheck 通过
- ✅ dashboard 测试通过（436 tests）
- ✅ Reviewer-04 审查通过
