### PR TITLE
STU-4336: chore(deps): bump hono 4.13.3 → 4.13.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "raven",
       "dependencies": {
-        "hono": "4.13.3",
+        "hono": "4.13.4",
         "micromatch": "^4.0.8",
         "next": "16.3.2",
         "vite": "8.2.2",
@@ -62,7 +62,7 @@
       "name": "@raven/proxy",
       "dependencies": {
         "gpt-tokenizer": "4.0.0",
-        "hono": "4.13.3",
+        "hono": "4.13.4",
         "socks": "^2.8.7",
         "zod": "^4.3.6",
       },
@@ -756,7 +756,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
+    "hono": ["hono@4.13.4", "", {}, "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "nanoid": "3.3.18"
   },
   "dependencies": {
-    "hono": "4.13.3",
+    "hono": "4.13.4",
     "micromatch": "^4.0.8",
     "next": "16.3.2",
     "vite": "8.2.2",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "gpt-tokenizer": "4.0.0",
-    "hono": "4.13.3",
+    "hono": "4.13.4",
     "socks": "^2.8.7",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary
- Bump `hono` 4.13.3 → 4.13.4 in root and `@raven/proxy`
- Sync `bun.lock` version + integrity
- No production source changes

Closes nocoo/raven#301
STU-4336

## Test plan
- [x] Local pre-commit gates green
- [x] `hono@4.13.4` resolves after install
- [x] Reviewer-01 approved local commits
- [ ] CI green on this PR

Note: socks5 drain test fix already on `main` via #304; this PR only contains the hono bump after rebase.