### PR TITLE
STU-4449 / STU-4582: chore(deps): upgrade @types/node to 26.4.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/dashboard": {
       "name": "dashboard",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -46,7 +46,7 @@
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "14.6.6",
-        "@types/node": "26.3.0",
+        "@types/node": "26.4.0",
         "@types/react": "19.2.18",
         "@types/react-dom": "^19.2.5",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
@@ -530,7 +530,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
+    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -32,7 +32,7 @@
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "14.6.6",
-    "@types/node": "26.3.0",
+    "@types/node": "26.4.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "^19.2.5",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",


### PR DESCRIPTION
## Summary

- Upgrade dashboard's `@types/node` development dependency to 26.4.0.
- Regenerate `bun.lock`, including the previously stale dashboard version record.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --filter dashboard lint`
- `bun run --filter dashboard typecheck`
- `bun run --filter dashboard test`
- `bun run --filter dashboard build`

Closes #308
