### PR TITLE
STU-5168: bump lucide-react to 1.41.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,11 +21,11 @@
     },
     "packages/dashboard": {
       "name": "dashboard",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "dependencies": {
         "@nocoo/basalt": "2.0.3",
         "clsx": "^2.1.1",
-        "lucide-react": "1.40.0",
+        "lucide-react": "1.41.0",
         "next": "16.3.4",
         "next-auth": "^5.0.0-beta.32",
         "react": "19.2.8",
@@ -806,7 +806,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.5.2.tgz", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@1.40.0", "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.40.0.tgz", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-MaG+8WnOXkDWz9XeElj7TnQ890tTZUB0a36i03aRRCKGWE6e7jJpmdCvtxxuxcjjdqyN6m4sL6qlHVuSUDtYgg=="],
+    "lucide-react": ["lucide-react@1.41.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q=="],
 
     "lz-string": ["lz-string@1.5.0", "https://registry.npmmirror.com/lz-string/-/lz-string-1.5.0.tgz", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@nocoo/basalt": "2.0.3",
     "clsx": "^2.1.1",
-    "lucide-react": "1.40.0",
+    "lucide-react": "1.41.0",
     "next": "16.3.4",
     "next-auth": "^5.0.0-beta.32",
     "react": "19.2.8",


### PR DESCRIPTION
## Summary

- Upgrade the Dashboard's `lucide-react` dependency from 1.40.0 to 1.41.0.
- Regenerate `bun.lock` and align its Dashboard workspace version with the 2.7.0 manifest.

## Validation

- `bun run test:all`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun install --frozen-lockfile`

Closes #333
Closes STU-5168

<!-- Multica reconciliation: STU-5168 -->
