### PR TITLE
STU-5170: chore(deps): bump hono to 4.13.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
       "name": "@raven/proxy",
       "dependencies": {
         "gpt-tokenizer": "4.0.0",
-        "hono": "4.13.5",
+        "hono": "4.13.7",
         "socks": "^2.8.10",
         "zod": "^4.5.4",
       },
@@ -736,7 +736,7 @@
 
     "hasown": ["hasown@2.0.3", "https://registry.npmmirror.com/hasown/-/hasown-2.0.3.tgz", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.13.5", "https://registry.npmmirror.com/hono/-/hono-4.13.5.tgz", {}, "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw=="],
+    "hono": ["hono@4.13.7", "", {}, "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "https://registry.npmmirror.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "gpt-tokenizer": "4.0.0",
-    "hono": "4.13.5",
+    "hono": "4.13.7",
     "socks": "^2.8.10",
     "zod": "^4.5.4"
   },


### PR DESCRIPTION
## Summary

- Upgrade the exact `@raven/proxy` Hono dependency from 4.13.5 to 4.13.7.
- Refresh the locked Hono package integrity record.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run test` (126 files, 1,983 tests)
- `bun run lint`
- `bun run typecheck`
- `bun run build`

Closes #332
Closes STU-5170
